### PR TITLE
fix(k8s): don't wait for pod termination in kkp

### DIFF
--- a/config.d/zsh/conf.d/k8s.zsh
+++ b/config.d/zsh/conf.d/k8s.zsh
@@ -54,5 +54,5 @@ kkp() {
   pods=$(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | \
     fzf --multi --preview 'kubecolor get pod {} -o wide --force-colors 2>/dev/null' \
         --header 'TAB to select multiple, ENTER to delete')
-  [[ -n "$pods" ]] && echo "$pods" | xargs kubectl delete pod
+  [[ -n "$pods" ]] && echo "$pods" | xargs kubectl delete pod --wait=false
 }


### PR DESCRIPTION
## Summary
- Add `--wait=false` to `kubectl delete pod` in `kkp` function so it returns to shell immediately instead of blocking until pods terminate

## Changelog
- fix(k8s): `kkp` no longer hangs after selecting pods to delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)