### PR TITLE
feat(packager): supply chain hardening for npm/bun/cargo

### DIFF
--- a/.bunfig.toml
+++ b/.bunfig.toml
@@ -1,2 +1,7 @@
 [install]
-minimumReleaseAge = 604800 # seconds
+minimumReleaseAge = 604800 # 7 days
+
+[install.lifecycle]
+postinstall = false
+preinstall = false
+prepare = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### March
 
+**Package manager supply chain hardening:**
+
+- New `packager.d/` directory for security configs (mirrors `git.d/`, `ssh.d/` pattern)
+- `link:npmrc` converge task: ensures `ignore-scripts=true` and `min-release-age=7` exist in `~/.npmrc`, enforces `chmod 600` (file contains auth tokens)
+- `link:cargo` task: symlinks `~/.cargo/config.toml` with `git-fetch-with-cli = true` (inherits system git's SSH/credential config from `git.d/`)
+- `.bunfig.toml`: disable lifecycle scripts (`postinstall`, `preinstall`, `prepare`), existing 7-day release age retained
+- Both tasks run as part of `task converge` via `link:` dependency chain
+
 **Move setup-macos into Taskfile DAG:**
 
 - Setup script reduced to ~20 lines: clone dotfiles, bootstrap go-task, `task setup`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -208,8 +208,8 @@ tasks:
     deps:
       - link:dotfiles
       - link:config
-      - link:gitconfig
-      - link:ssh
+      - patch:gitconfig
+      - patch:ssh
       - link:brewfile
       - link:claude-hooks
       - link:sheldon
@@ -249,7 +249,7 @@ tasks:
           printf "{{.LINK}} ~/.config/%s\n" "$name"
         done
 
-  link:gitconfig:
+  patch:gitconfig:
     desc: Ensure gitconfig includes dotfiles
     cmds:
       - |
@@ -258,7 +258,7 @@ tasks:
         printf '\n[include]\npath = ~/.dotfiles/git.d/core.conf\n' >> "$HOME/.gitconfig"
         printf "{{.OK}} gitconfig include\n"
 
-  link:ssh:
+  patch:ssh:
     desc: Ensure SSH config includes dotfiles
     cmds:
       - |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,6 +213,8 @@ tasks:
       - link:brewfile
       - link:claude-hooks
       - link:sheldon
+      - link:npmrc
+      - link:cargo
 
   link:dotfiles:
     desc: Symlink dotfiles (.* → ~)
@@ -292,6 +294,37 @@ tasks:
           .hooks.PostToolUse += [{"matcher": "Write|Edit", "hooks": [{"type": "command", "command": "~/.dotfiles/hooks/gastown-file-changed.sh"}]}]
         ' "$claude_settings" > "$claude_settings.tmp" && mv "$claude_settings.tmp" "$claude_settings"
         printf "{{.OK}} claude hooks: gastown\n"
+
+  link:npmrc:
+    desc: Ensure npmrc has security defaults
+    cmds:
+      - |
+        npmrc="$HOME/.npmrc"
+        [ -f "$npmrc" ] || touch "$npmrc"
+        chmod 600 "$npmrc"
+        changed=0
+        while IFS= read -r line || [ -n "$line" ]; do
+          case "$line" in \#*|"") continue ;; esac
+          key="${line%%=*}"
+          grep -q "^${key}=" "$npmrc" || { echo "$line" >> "$npmrc"; changed=1; }
+        done < "{{.DOTFILES}}/packager.d/npmrc-security"
+        [ "$changed" = 1 ] && printf "{{.OK}} npmrc security defaults\n"
+        exit 0
+
+  link:cargo:
+    desc: Symlink cargo security config
+    cmds:
+      - |
+        mkdir -p "$HOME/.cargo"
+        target="$HOME/.cargo/config.toml"
+        src="{{.DOTFILES}}/packager.d/cargo-config.toml"
+        [ -L "$target" ] && [ "$(readlink "$target")" = "$src" ] && exit 0
+        if [ -f "$target" ] && [ ! -L "$target" ]; then
+          printf "{{.WARN}} ~/.cargo/config.toml exists — merge %s manually\n" "$src"
+          exit 0
+        fi
+        ln -sf "$src" "$target"
+        printf "{{.LINK}} cargo config\n"
 
   link:sheldon:
     desc: Sheldon plugin manager

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,7 +213,7 @@ tasks:
       - link:brewfile
       - link:claude-hooks
       - link:sheldon
-      - link:npmrc
+      - patch:npmrc
       - link:cargo
 
   link:dotfiles:
@@ -295,7 +295,7 @@ tasks:
         ' "$claude_settings" > "$claude_settings.tmp" && mv "$claude_settings.tmp" "$claude_settings"
         printf "{{.OK}} claude hooks: gastown\n"
 
-  link:npmrc:
+  patch:npmrc:
     desc: Ensure npmrc has security defaults
     cmds:
       - |

--- a/packager.d/cargo-config.toml
+++ b/packager.d/cargo-config.toml
@@ -1,0 +1,4 @@
+# Supply chain defaults — symlinked from dotfiles
+[net]
+# Use system git (respects SSH agent, credential helpers, git.d/ hardening)
+git-fetch-with-cli = true

--- a/packager.d/npmrc-security
+++ b/packager.d/npmrc-security
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
## Summary
- New `packager.d/` with security configs (same pattern as `git.d/`, `ssh.d/`)
- `link:npmrc` converge task patches `~/.npmrc` in-place (can't symlink — has creds), enforces `chmod 600`, ensures `ignore-scripts=true` and `min-release-age=7` are present
- `link:cargo` symlinks `~/.cargo/config.toml` with `git-fetch-with-cli=true` so cargo inherits system git's SSH/credential hardening
- `.bunfig.toml` lifecycle scripts (`postinstall`, `preinstall`, `prepare`) disabled
- Both tasks wired into `link:` → runs on every `task converge`

## Test plan
- [x] `task link:npmrc` — idempotent when settings already exist, adds missing keys
- [x] `task link:cargo` — creates symlink, warns if manual config exists
- [x] `~/.npmrc` permissions verified at 600
- [x] Taskfile parses clean (`task --list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)