### PR TITLE
fix(prune): deduplicate nested candidate directories

### DIFF
--- a/crates/src/bin/prune.rs
+++ b/crates/src/bin/prune.rs
@@ -116,6 +116,15 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Remove children whose parent is already a candidate (deleting parent nukes children)
+    candidates.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let all_paths: Vec<PathBuf> = candidates.iter().map(|(p, _)| p.clone()).collect();
+    candidates.retain(|(path, _)| {
+        !all_paths
+            .iter()
+            .any(|other| other != path && path.starts_with(other))
+    });
+
     // Sort by size ascending
     candidates.sort_by_key(|(_, size)| *size);
 
@@ -252,5 +261,28 @@ mod tests {
 
         let size = get_dir_size(temp_dir.path()).unwrap();
         assert_eq!(size, 6); // 3 + 3 bytes
+    }
+
+    #[test]
+    fn test_nested_candidates_deduped() {
+        // Simulate the candidate dedup logic: child paths should be removed
+        // when their parent is already a candidate
+        let mut candidates: Vec<(PathBuf, u64)> = vec![
+            (PathBuf::from("./foo"), 0),
+            (PathBuf::from("./foo/bar"), 0),
+            (PathBuf::from("./baz"), 0),
+        ];
+
+        candidates.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let all_paths: Vec<PathBuf> = candidates.iter().map(|(p, _)| p.clone()).collect();
+        candidates.retain(|(path, _)| {
+            !all_paths
+                .iter()
+                .any(|other| other != path && path.starts_with(other))
+        });
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].0, PathBuf::from("./baz"));
+        assert_eq!(candidates[1].0, PathBuf::from("./foo"));
     }
 }


### PR DESCRIPTION
## Summary
- Prune was listing both parent and child dirs as candidates, then failing with "No such file or directory" when trying to delete children after the parent was already nuked
- Filters out any candidate path whose ancestor is already in the candidate list before displaying/deleting

## Test plan
- [x] `cargo test --bin prune` — 9 tests pass including new `test_nested_candidates_deduped`
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)