### PR TITLE
feat: scheduled mise upgrade via launchd

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,6 +224,7 @@ tasks:
       - link:brewfile
       - link:claude-hooks
       - link:sheldon
+      - link:launchagents
       - patch:npmrc
       - link:cargo
 
@@ -336,6 +337,27 @@ tasks:
         fi
         ln -sf "$src" "$target"
         printf "{{.LINK}} cargo config\n"
+
+  link:launchagents:
+    desc: Symlink and reload LaunchAgents
+    platforms: [darwin]
+    cmds:
+      - |
+        mkdir -p "$HOME/Library/LaunchAgents"
+        for f in "{{.DOTFILES}}/launchd"/*.plist; do
+          [ -e "$f" ] || continue
+          name=$(basename "$f")
+          label="${name%.plist}"
+          target="$HOME/Library/LaunchAgents/$name"
+          [ -L "$target" ] && [ "$(readlink "$target")" = "$f" ] || {
+            rm -f "$target"
+            ln -s "$f" "$target"
+            printf "{{.LINK}} LaunchAgents/%s\n" "$name"
+          }
+          launchctl bootout "gui/$(id -u)/$label" 2>/dev/null || true
+          launchctl bootstrap "gui/$(id -u)" "$target"
+          printf "{{.OK}} %s (loaded)\n" "$label"
+        done
 
   link:sheldon:
     desc: Sheldon plugin manager

--- a/launchd/com.mise.upgrade.plist
+++ b/launchd/com.mise.upgrade.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mise.upgrade</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/mise</string>
+        <string>upgrade</string>
+        <string>--yes</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>StandardOutPath</key>
+    <string>/tmp/mise-upgrade.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mise-upgrade.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds `launchd/com.mise.upgrade.plist` — runs `mise upgrade --yes` hourly in the background
- Adds `link:launchagents` task that symlinks plists and `bootout`+`bootstrap` on every converge, so schedule changes are picked up automatically
- Generic loop handles any future plists dropped into `launchd/`

## Test plan
- [x] `task link:launchagents` symlinks and loads the agent
- [x] `launchctl print gui/$(id -u)/com.mise.upgrade` confirms it's registered
- [x] Won't wake the laptop — no `WakeFromSleep` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)