### PR TITLE
feat: scheduled mise upgrade + fix zsh eval cache invalidation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,6 +224,7 @@ tasks:
       - link:brewfile
       - link:claude-hooks
       - link:sheldon
+      - link:launchagents
       - patch:npmrc
       - link:cargo
 
@@ -336,6 +337,27 @@ tasks:
         fi
         ln -sf "$src" "$target"
         printf "{{.LINK}} cargo config\n"
+
+  link:launchagents:
+    desc: Symlink and reload LaunchAgents
+    platforms: [darwin]
+    cmds:
+      - |
+        mkdir -p "$HOME/Library/LaunchAgents"
+        for f in "{{.DOTFILES}}/launchd"/*.plist; do
+          [ -e "$f" ] || continue
+          name=$(basename "$f")
+          label="${name%.plist}"
+          target="$HOME/Library/LaunchAgents/$name"
+          [ -L "$target" ] && [ "$(readlink "$target")" = "$f" ] || {
+            rm -f "$target"
+            ln -s "$f" "$target"
+            printf "{{.LINK}} LaunchAgents/%s\n" "$name"
+          }
+          launchctl bootout "gui/$(id -u)/$label" 2>/dev/null || true
+          launchctl bootstrap "gui/$(id -u)" "$target"
+          printf "{{.OK}} %s (loaded)\n" "$label"
+        done
 
   link:sheldon:
     desc: Sheldon plugin manager

--- a/config.d/zsh/conf.d/25-mise.zsh
+++ b/config.d/zsh/conf.d/25-mise.zsh
@@ -1,7 +1,7 @@
 # Mise (runtime version manager)
 command -v mise >/dev/null || return
 
-_cached_eval "mise" "mise activate zsh"
+_cached_eval "mise" "mise activate zsh" "$(command -v mise)"
 
 alias m='mise'
 alias mi='mise i'

--- a/config.d/zsh/conf.d/fzf.zsh
+++ b/config.d/zsh/conf.d/fzf.zsh
@@ -1,7 +1,7 @@
 # FZF configuration
 command -v fzf >/dev/null || return
 
-_cached_eval "fzf" "fzf --zsh"
+_cached_eval "fzf" "fzf --zsh" "$(command -v fzf)"
 
 if command -v bat >/dev/null; then
   alias fzf='fzf \

--- a/config.d/zsh/conf.d/zoxide.zsh
+++ b/config.d/zsh/conf.d/zoxide.zsh
@@ -1,4 +1,4 @@
 # Zoxide (smart cd)
 command -v zoxide >/dev/null || return
 
-_cached_eval "zoxide" "zoxide init zsh"
+_cached_eval "zoxide" "zoxide init zsh" "$(command -v zoxide)"

--- a/config.d/zsh/conf.d/zz-starship.zsh
+++ b/config.d/zsh/conf.d/zz-starship.zsh
@@ -2,4 +2,4 @@
 command -v starship >/dev/null || return
 
 export STARSHIP_CONFIG=~/.config/starship/config.toml
-_cached_eval "starship" "starship init zsh"
+_cached_eval "starship" "starship init zsh" "$(command -v starship)"

--- a/launchd/com.mise.upgrade.plist
+++ b/launchd/com.mise.upgrade.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mise.upgrade</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/mise</string>
+        <string>upgrade</string>
+        <string>--yes</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>StandardOutPath</key>
+    <string>/tmp/mise-upgrade.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mise-upgrade.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Two related commits landed together:

### 1. `feat: scheduled mise upgrade via launchd` ([1e2410c](https://github.com/radiosilence/dotfiles/commit/1e2410c))

(Existing commit on branch — author's own.)

### 2. `fix(zsh): invalidate _cached_eval when mise bumps a tool`

After a mise-driven tool upgrade (e.g. starship 1.24.2 → 1.25.0), `zsh` would throw `no such file or directory: …/1.24.2/starship` on every prompt render until the cached init script was manually deleted.

Root cause: `_cached_eval` in `config.d/zsh/conf.d/00-prelude.zsh` regenerates only when its optional `dep` arg is newer than the cache (`[[ \$dep -nt \$cache_file ]]`). The starship/mise/fzf/zoxide call sites didn't pass one, so the cache was pinned to whichever version was active the first time the shell ran.

Fix: pass `"\$(command -v TOOL)"` as the dep. That resolves to the current on-disk binary path at shell startup; when mise activates a new version the path's mtime moves forward → cache regens on next shell. Applies to starship, mise, fzf, zoxide. Sheldon already had a proper dep (its plugins.toml).

## Test plan

- [x] \`rm ~/.cache/zsh/eval/starship.zsh\` then open new shell → prompt renders, cache rebuilt with current binary path
- [ ] Next mise upgrade doesn't leave a dangling cache (observable only on next upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)