### PR TITLE
feat(lima): payload-detonation sandbox with in-box Claude agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ## 2026
 
-### May
+### June
+
+**Lima payload-detonation sandbox (`jail`):**
+
+- `config.d/lima/isolated.yaml` (symlinked to `~/.config/lima/`) — a throwaway arm64 Ubuntu VM for detonating untrusted samples that hit the org (scripts/JS/Python/macros) and running Claude inside as an autonomous triage agent. The point is to box *Claude itself*: an agent with `--dangerously-skip-permissions` on attacker-controlled input is a prompt-injection target, so it runs where a hijack can't reach the host
+- Host fs is invisible to the guest except `~/lima-jail` ↔ `/jail` (the one quarantine mount); no home mount, no SSH-agent forwarding, no env passthrough. Egress stays *on* — the sample (and a tricked agent) can reach the web, which is the tradeoff for observing real C2 behaviour. `tcpdump` auto-starts at boot via a systemd unit writing full pcap to `/jail/capture.pcap`, so the capture lands on the host and survives nuking the VM — every exfil/pivot attempt is on the record
+- Claude auth is a throwaway `claude setup-token`, injected at runtime into the agent's process env only (`CLAUDE_CODE_OAUTH_TOKEN` via `limactl shell jail -- env …`) — never baked into the committed YAML, never written to the contaminated `/jail` mount. Revoke after each session; blast radius of a scraped token is capped at "some API spend until revoked". The box pre-seeds `hasCompletedOnboarding`/`bypassPermissionsModeAccepted` so an injected token authenticates without tripping interactive gates — agent runs must be headless (`-p`), the TUI still shows a login screen
+- `config.d/zsh/conf.d/lima.zsh` — helpers: `jail-rebuild` (delete + fresh box; config changes only land on first boot, so rebuild = recreate not restart), `jail-mint` (runs `setup-token`, greps the bare `sk-ant-oat…` out of its banner noise, caches in `$JAIL_TOKEN`), `jail-claude` (auto-mints on first use then injects), `jail-send`, `jail-shell`, `jail-pcap`, `jail-nuke`. One fresh box per sample — vz has no clean snapshot-revert, so never reuse a contaminated guest
+- Known gap: in-guest capture can be tampered by capture-aware malware wiping `/jail`. Host-side capture via `socket_vmnet` would be tamper-proof — deferred
 
 **mise GitHub token via `gh auth token`:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 - Claude auth is a throwaway `claude setup-token`, injected at runtime into the agent's process env only (`CLAUDE_CODE_OAUTH_TOKEN` via `limactl shell jail -- env …`) — never baked into the committed YAML, never written to the contaminated `/jail` mount. Revoke after each session; blast radius of a scraped token is capped at "some API spend until revoked". The box pre-seeds `hasCompletedOnboarding`/`bypassPermissionsModeAccepted` so an injected token authenticates without tripping interactive gates — agent runs must be headless (`-p`), the TUI still shows a login screen
 - `config.d/zsh/conf.d/lima.zsh` — helpers: `jail-rebuild` (delete + fresh box; config changes only land on first boot, so rebuild = recreate not restart), `jail-mint` (runs `setup-token`, greps the bare `sk-ant-oat…` out of its banner noise, caches in `$JAIL_TOKEN`), `jail-claude` (auto-mints on first use then injects), `jail-send`, `jail-shell`, `jail-pcap`, `jail-nuke`. One fresh box per sample — vz has no clean snapshot-revert, so never reuse a contaminated guest
 - Known gap: in-guest capture can be tampered by capture-aware malware wiping `/jail`. Host-side capture via `socket_vmnet` would be tamper-proof — deferred
+- `brewfiles.d/virtual.rb` declares `lima` under a new `virtual` brew role (documented in `dotfiles-roles.yml.template`), so a fresh machine reinstalls Lima via `brew bundle`
 
 **mise GitHub token via `gh auth token`:**
 

--- a/brewfiles.d/virtual.rb
+++ b/brewfiles.d/virtual.rb
@@ -1,0 +1,1 @@
+brew 'lima'

--- a/config.d/lima/isolated.yaml
+++ b/config.d/lima/isolated.yaml
@@ -1,0 +1,110 @@
+# Payload detonation sandbox (scripts / JS / Python / macros).
+# Canonical copy lives in dotfiles; symlinked to ~/.config/lima/isolated.yaml.
+# Shell helpers (jail-rebuild, jail-claude, ...) are in zsh/conf.d/lima.zsh.
+#
+#   - Host filesystem: INVISIBLE except ~/lima-jail <-> /jail (the quarantine drop box).
+#   - Egress: ON. The payload can reach the real web; so can its C2. See WARNINGS below.
+#   - Capture: tcpdump auto-starts at boot, full pcap of every interface -> /jail/capture.pcap
+#     (written live/unbuffered, lands on the HOST, survives nuking the VM).
+#   - Analysis: pull the pcap from ~/lima-jail and open it in Wireshark on the HOST,
+#     where it's not sitting in the blast radius. tshark is also in the guest.
+#
+# RUNBOOK (one fresh VM per sample):
+#   mkdir -p ~/lima-jail
+#   limactl start --name=jail ~/.config/lima/isolated.yaml   # or: jail-rebuild
+#   cp suspicious_sample ~/lima-jail/          # drop it in   # or: jail-send <file>
+#   limactl shell jail                         # detonate: cd /jail && ./run-it
+#   # ...let it run...
+#   open ~/lima-jail/capture.pcap              # analyse on host (Wireshark)
+#   limactl delete -f jail                     # BURN IT. Next sample = fresh VM.
+#
+# CLAUDE AUTH (throwaway, revocable, injected at RUNTIME -- never baked in):
+#   # 1. Mint a disposable token on the HOST (uses your sub, revocable any time):
+#   export JAIL_TOKEN=$(claude setup-token)        # or an API key from console
+#   # 2. Run claude IN the box with the token only in its process env:
+#   limactl shell jail -- env CLAUDE_CODE_OAUTH_TOKEN="$JAIL_TOKEN" \
+#     bash -lc 'cd /jail && claude'                # or just: jail-claude
+#   # 3. When done: revoke it. Settings -> the session/key you minted. Then nuke VM.
+#   # The token never touches /jail or the YAML, so it's not on the contaminated
+#   # mount -- only in claude's environ inside the disposable guest.
+#
+# WARNINGS (read these, choom):
+#   * Real egress = the sample phones its real C2, may pull a live second stage,
+#     and that traffic exits YOUR org's public IP. Run this off-corp / behind a VPN
+#     if you don't want to tip off the attacker or attribute it to you.
+#   * /jail is the malware's ONE window to your host fs. It can wipe/encrypt what's
+#     there, including capture.pcap. Copy the pcap out promptly, or switch to
+#     host-side capture (socket_vmnet) for a tamper-proof record.
+#   * vz has no clean snapshot-revert. Destroy + recreate per sample. Never reuse.
+
+vmType: "vz"
+os: "Linux"
+
+images:
+  - location: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    arch: "aarch64"
+
+cpus: 4
+memory: "4GiB"
+disk: "20GiB"
+
+# The ONLY host path the guest can see. Treat it as contaminated quarantine.
+mounts:
+  - location: "~/lima-jail"
+    mountPoint: "/jail"
+    writable: true
+
+containerd:
+  system: false
+  user: false
+
+provision:
+  # Analysis + runtime tooling. ripgrep/jq/file for triage, the interpreters to
+  # detonate scripts, tcpdump/tshark/dnsutils for traffic.
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y \
+        tcpdump tshark dnsutils \
+        python3 python3-pip \
+        nodejs npm \
+        ripgrep jq file unzip git curl
+      # Claude Code, for in-box analysis. Auth is injected at RUNTIME as an env
+      # var (see header) -- NEVER baked in here, never via the /jail mount.
+      npm install -g @anthropic-ai/claude-code
+
+  # Pre-clear Claude's interactive gates so an injected token Just Works in both
+  # headless (-p) and TUI mode -- no onboarding/theme/bypass-accept prompts. The
+  # token itself is NEVER seeded here; it's injected at runtime (see jail-claude).
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux
+      cat > "$HOME/.claude.json" <<'EOF'
+      {"hasCompletedOnboarding": true, "bypassPermissionsModeAccepted": true, "theme": "dark"}
+      EOF
+
+  # Auto-capture: tcpdump on all interfaces, unbuffered, from boot -> host-visible pcap.
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux
+      cat > /etc/systemd/system/jail-capture.service <<'EOF'
+      [Unit]
+      Description=jail full-packet capture
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      ExecStart=/usr/bin/tcpdump -i any -U -w /jail/capture.pcap
+      Restart=always
+      RestartSec=1
+
+      [Install]
+      WantedBy=multi-user.target
+      EOF
+      systemctl daemon-reload
+      systemctl enable --now jail-capture.service

--- a/config.d/zsh/conf.d/lima.zsh
+++ b/config.d/zsh/conf.d/lima.zsh
@@ -1,0 +1,52 @@
+# Lima payload-detonation sandbox ("jail").
+# Template + full runbook/warnings: ~/.config/lima/isolated.yaml
+# One fresh box per sample. Host fs is invisible to it except ~/lima-jail <-> /jail.
+
+export JAIL_TEMPLATE="$HOME/.config/lima/isolated.yaml"
+export JAIL_DROP="$HOME/lima-jail"
+
+# Burn the old box and build a clean one (config changes only land on fresh boot).
+jail-rebuild() {
+  limactl delete -f jail 2>/dev/null
+  mkdir -p "$JAIL_DROP"
+  limactl start --name=jail "$JAIL_TEMPLATE" --tty=false
+}
+
+# Shell into the box.
+alias jail-shell='limactl shell jail'
+
+# Drop file(s) into the quarantine mount the guest can see.
+jail-send() { cp -R "$@" "$JAIL_DROP"/; }
+
+# Open the capture on the host (Wireshark), where it's outside the blast radius.
+alias jail-pcap='open "$JAIL_DROP/capture.pcap"'
+
+# Mint a throwaway OAuth token into $JAIL_TOKEN (interactive once per shell).
+# setup-token emits a banner + the token; we grep out just the sk-ant-oat... bit.
+# Runs on the HOST (needs a browser); only the clean token gets injected later.
+jail-mint() {
+  local tok
+  echo "minting throwaway token on host (revoke it when done)…" >&2
+  tok=$(claude setup-token | grep -oE 'sk-ant-oat[A-Za-z0-9_-]+' | tail -1)
+  if [[ -z "$tok" ]]; then
+    echo "no token captured — run 'claude setup-token' by hand, then: export JAIL_TOKEN=<token>" >&2
+    return 1
+  fi
+  export JAIL_TOKEN="$tok"
+  echo "minted ${tok:0:16}… (cached in \$JAIL_TOKEN for this shell)" >&2
+}
+
+# Run Claude IN the box as an agent. Auto-mints on first use (cached in
+# $JAIL_TOKEN), then injects the token into claude's process env inside the
+# guest -- never written to /jail, never in the committed YAML.
+# Agent use is HEADLESS -- pass -p, or the TUI hits the interactive auth gate:
+#   jail-claude --dangerously-skip-permissions -p "triage /jail/sample"
+# Revoke the token in settings when the session's done.
+jail-claude() {
+  [[ -n "$JAIL_TOKEN" ]] || jail-mint || return 1
+  limactl shell jail -- env CLAUDE_CODE_OAUTH_TOKEN="$JAIL_TOKEN" \
+    bash -lc 'cd /jail && exec claude "$@"' _ "$@"
+}
+
+# Burn it down.
+alias jail-nuke='limactl delete -f jail'

--- a/dotfiles-roles.yml.template
+++ b/dotfiles-roles.yml.template
@@ -17,3 +17,4 @@ roles:
   # - tailscale    # tailscale
   # - sharing      # fun things
   # - ai           # tbh just claude
+  # - virtual      # lima (payload-detonation sandbox)


### PR DESCRIPTION
## What this is

A throwaway arm64 Ubuntu VM (`jail`) for detonating untrusted samples that hit the org (scripts/JS/Python/macros) and running Claude inside as an autonomous triage agent.

The load-bearing idea: it boxes **Claude itself**. An agent running `--dangerously-skip-permissions` over attacker-controlled input is a prompt-injection target — so it runs somewhere a hijack can't reach the host, your secrets, or the rest of your fs.

## Load-bearing decisions

- **Host fs invisible** except `~/lima-jail` ↔ `/jail`. No home mount, no SSH-agent forwarding, no env passthrough.
- **Egress stays on** — the sample (and a tricked agent) can reach the web. That's the deliberate tradeoff for observing real C2 behaviour; the containment is host-side, not network-side.
- **tcpdump auto-captures** to `/jail/capture.pcap` from boot via a systemd unit — lands on the host, survives nuking the VM, so every exfil/pivot attempt is on record.
- **Throwaway auth** — `claude setup-token` minted on the host, injected at runtime into the agent's process env (`CLAUDE_CODE_OAUTH_TOKEN`) only. Never in the committed YAML, never on the `/jail` mount. Revoke per session.
- **Onboarding pre-seeded** so an injected token authenticates without tripping interactive gates. Agent runs must be headless (`-p`); the TUI still shows a login screen.
- **Fresh box per sample** — vz has no clean snapshot-revert, so reuse is banned.

## How to confirm it works

1. `jail-rebuild` — boots, provisions tooling + Claude
2. `jail-claude -p "say OK"` — auto-mints a token (browser once), injects, runs headless; `OK` back = end-to-end green
3. Smoke-tested: host fs invisible (`ls ~` empty of real files, no `/Users`), `/jail` round-trips, egress returns HTTP 200, `capture.pcap` recording, dummy token → clean 401 (proves the env var is read with zero prompts)

## Known gap

In-guest capture can be tampered by capture-aware malware wiping `/jail`. Host-side capture via `socket_vmnet` would be tamper-proof — deferred. A RO-mount + `limactl copy` findings-out model is the planned follow-up for tighter isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)