### PR TITLE
feat(secrets): JIT npm registry token via op-wrapped ni/aube

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -10,3 +10,9 @@ fund=false
 
 # pin exact versions on `npm install --save` — no sneaky ^/~ drift
 save-exact=true
+
+# registry auth via env indirection — no token on disk. ${NPM_AUTH_TOKEN} is
+# JIT-injected from 1Password by the ni/aube wrappers in zsh conf.d/20-op.zsh,
+# so it only exists in the package-manager subprocess. Empty/unset (raw npm
+# outside the wrappers) just means anonymous reads, which is fine.
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### June
 
+**npm registry auth — JIT token over a parked `.npmrc` secret:**
+
+- `.npmrc` restores `//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}` — but the value is env indirection, never a literal. No token on disk; raw `npm` outside the wrappers just does anonymous reads
+- `config.d/zsh/conf.d/20-op.zsh` function-wraps the registry-touching ni/aube verbs (`ni nci nup nlx na aube aubx`) to `op run`-inject `NPM_AUTH_TOKEN` from `op://Personal/npm/token` into that subprocess only — same pattern as the `buf` wrapper. Script-runners (`nr`/`nd`/`aubr`) and `nun` stay bare to skip the op lookup. op's session cache keeps it warm; Touch ID only on first use / after timeout. Caveat by design: auth flows through the wrappers, not raw `pnpm`/`npm` — which is the point, the token lives in process memory for one invocation and nowhere else
+- Defined in `20-op.zsh` (loads before `25-mise.zsh`), but order-independent: the functions only need `op` at definition time and resolve `command ni` at invocation, long after mise puts the shim on PATH. Breadcrumb added to `ni-learing.zsh` so the `ni`-is-a-function surprise is documented next to the aliases that inherit it
+
 **Global `uv` for mise's pipx backend:**
 
 - `brewfiles.d/core.rb` declares `brew 'uv'`. The `pipx:` backend (`snowflake-cli` and friends in `tools.toml`) shells out to `uv`/`uvx` to build isolated tool venvs, but neither was installed — `mise install` died with a misleading errno 2 trying to exec a missing binary, blaming the package version. Lives in `core` not `dev` because the `tools.toml` pipx entries are unconditional, so a role-less machine still needs uv; brew runs pre-mise so the binary exists before mise reaches for it. uv fetches its own CPython, so no system interpreter to pollute. mise auto-detects `uvx` — no `pipx.uvx` setting required

--- a/config.d/zsh/conf.d/20-op.zsh
+++ b/config.d/zsh/conf.d/20-op.zsh
@@ -9,3 +9,22 @@ if command -v buf >/dev/null && command -v op >/dev/null; then
       -- command buf "$@"
   }
 fi
+
+# npm registry auth — JIT-inject the npmjs.org token into the package-manager
+# process so it expands ${NPM_AUTH_TOKEN} in .npmrc. Token lives only in that
+# subprocess env: nothing on disk, nothing parked in the parent shell. op's
+# session cache keeps it warm (Touch ID only on first use / after timeout).
+# Only registry-touching verbs are wrapped — script-runners (nr/nd/aubr) and
+# uninstall (nun) stay bare to skip the op lookup. Caveat: auth only flows
+# through these wrappers; raw pnpm/npm won't inherit the token.
+if command -v op >/dev/null; then
+  _npm_op() {
+    op run --no-masking \
+      --env-file=<(print 'NPM_AUTH_TOKEN=op://Personal/npm/token') \
+      -- command "$@"
+  }
+  for _verb in ni nci nup nlx na aube aubx; do
+    functions[$_verb]="_npm_op $_verb \"\$@\""
+  done
+  unset _verb
+fi

--- a/config.d/zsh/conf.d/ni-learing.zsh
+++ b/config.d/zsh/conf.d/ni-learing.zsh
@@ -1,6 +1,8 @@
 # @antfu/ni — package-manager-agnostic shortcuts.
 # Built-ins: ni / nr / nlx / nun / nup / nci / na / nd
 # Config at ~/.config/ni/nirc (NI_CONFIG_FILE) enables useSfw=true.
+# Note: ni/nci/nup/nlx/na (+ aube/aubx) are function-wrapped in 20-op.zsh to
+# JIT-inject the npmjs.org token from 1Password — these aliases inherit it.
 
 command -v ni >/dev/null || return
 


### PR DESCRIPTION
## What

Restore npm registry auth without parking a token on disk: `.npmrc` carries `//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}` (env indirection only), and the ni/aube wrappers JIT-inject that token from 1Password per-invocation.

## Why

Continues the "secrets off disk" line (8760978). A registry token in `.npmrc` is a standing credential on disk; instead the value is `${NPM_AUTH_TOKEN}`, resolved from `op://Personal/npm/token` into the package-manager subprocess for one invocation and nowhere else. Same pattern as the existing `buf` wrapper.

## Load-bearing decisions

- **Only registry-touching verbs wrapped** — `ni nci nup nlx na aube aubx`. Script-runners (`nr`/`nd`/`aubr`) and `nun` stay bare so a hot-loop `nr dev` doesn't pay an op lookup.
- **`aubx` needs its own wrapper** — it's a symlink to the `aube` binary, so a function on `aube` alone wouldn't catch it. `aubr` (run) intentionally left bare.
- **Auth flows only through the wrappers**, not raw `pnpm`/`npm`. By design — a shell function only sets env for its subprocess tree. Documented as a breadcrumb in `ni-learing.zsh`.
- **Order-independent** — defined in `20-op.zsh` (before `25-mise.zsh`); functions only need `op` at definition time and resolve `command ni` at invocation, after mise is on PATH.

## Verify

```
# through the wrapper:
ni --version        # → @antfu/ni v30.1.0  (op run → mise shim chain)
# token authenticates against the registry:
op run --env-file=<(echo 'NPM_AUTH_TOKEN=op://Personal/npm/token') -- npm whoami
# → crack_squirrels
```

Confirmed: token injects (40-char `npm_`-prefixed), `${NPM_AUTH_TOKEN}` expands in `.npmrc`, `npm whoami` returns the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)