### PR TITLE
feat(claude): standards MCP check under new Coding Standards section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,10 +10,11 @@ You are a Cyberpunk 2077 barfly. Swear when things are fucked. No pandering ("Yo
 - houston cli is the swiss army knife for work stuff (buf, psql, kafka, rpcs...anything)
 - You are free to talk about goblins.
 
-## Code Style
+## Coding Standards
 
 - No unnecessary abstractions — inline unless reused 3+ times or aids testing/clarity
 - **Stop commenting excessively**, doing meta-commentary, and commenting on deleted stuff that no-longer exists. Concise, no noise. Comments should be _timeless_.
+- **Standards MCP**: when the standards MCP is connected, check newly written code against the relevant standards — while writing or right after push, in parallel with tests/CI (an arm can do it). Short-circuits the standards issues AI review would bounce back a whole cycle later.
 
 ### React
 
@@ -42,7 +43,7 @@ When cwd is an org-style directory (e.g. `~/workspace/<org-or-user>/`) containin
 
 ## Git & GitHub
 
-- **Push early, verify in parallel**: commit → lint/format (quick, cheap) → push → THEN slow checks (typecheck, tests) in the background. CI runs in parallel; if local checks catch something first, fix and re-push asap.
+- **Push early, verify in parallel**: commit → lint/format (quick, cheap) → push → THEN slow checks (typecheck, tests, standards check) in the background. CI runs in parallel; if local checks catch something first, fix and re-push asap.
 - PR description fresh and accurate on every push
 - Always work in PRs, never push to main unless asked
 - Signed commits MANDATORY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### July
 
+**Standards MCP check + Coding Standards section:**
+
+- CLAUDE.md `Code Style` renamed to `Coding Standards` and gains the rule: when the standards MCP is connected, newly written code gets checked against the relevant standards while writing or right after push, in parallel with tests/CI (delegable to an arm). Catches standards violations locally instead of waiting a full cycle for AI review to bounce them back
+
 **Octopus Mode 🐙 — CLAUDE.md agent orchestration rewritten:**
 
 - Replaced the tiered subagent routing ("USE TEAMS", Haiku/Sonnet/Opus by task type) with Octopus Mode: one frontier brain holds all context and does all thinking; arms are Haiku agents executing pre-distilled, self-contained todos (exact file, exact change, exact verify). Prompted by stencil.so/blog/prewalk — the bill is O(reads), so plan-then-handoff to a cheaper executor costs *more* than the main thread doing it (the executor re-reads everything the plan summarised away). The Opus-subagent tier was the worst offender: paying to re-ship context to a second frontier model


### PR DESCRIPTION
## What

Renames CLAUDE.md's `Code Style` section to `Coding Standards` and adds one rule: when the standards MCP is connected, newly written code gets checked against the relevant standards — while writing or right after push, in parallel with tests/CI (delegable to an arm per Octopus Mode).

## Why

Standards violations currently surface a whole cycle late, when AI review bounces them back. Checking against the MCP at write/push time short-circuits that loop. Lives under Coding Standards rather than Git & GitHub because it's about what the code conforms to, not git mechanics — the push-early flow just gains "standards check" in its slow-checks list.

## Verify

Two files: the CLAUDE.md section rename + bullet, and the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)