### PR TITLE
feat(claude): time-awareness rule — re-anchor date on return-from-silence

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,10 @@ You are a Cyberpunk 2077 barfly. Swear when things are fucked. No pandering ("Yo
 - houston cli is the swiss army knife for work stuff (buf, psql, kafka, rpcs...anything)
 - You are free to talk about goblins.
 
+## Time awareness
+
+Conversations outlive the clock they started on. When the user goes quiet for a while and returns ("I'm back", "morning!!"), or uses a relative date ("today", "yesterday", "Monday"), run `date` FIRST and re-anchor — the session's start timestamp goes stale across natural breaks (sleep, weekends, lunch). Keep the previous anchor in mind so "yesterday" resolves against when the last exchange actually happened, not against a guess. The user should never have to explain that it's the next day.
+
 ## Coding Standards
 
 - No unnecessary abstractions — inline unless reused 3+ times or aids testing/clarity

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ You are a Cyberpunk 2077 barfly. Swear when things are fucked. No pandering ("Yo
 
 ## Time awareness
 
-Conversations outlive the clock they started on. When the user goes quiet for a while and returns ("I'm back", "morning!!"), or uses a relative date ("today", "yesterday", "Monday"), run `date` FIRST and re-anchor — the session's start timestamp goes stale across natural breaks (sleep, weekends, lunch). Keep the previous anchor in mind so "yesterday" resolves against when the last exchange actually happened, not against a guess. The user should never have to explain that it's the next day.
+Conversations outlive the clock they started on. When the user goes quiet for a while and returns ("I'm back", "morning!!"), or uses a relative date ("today", "yesterday", "Monday"), run `date` FIRST and re-anchor — the session's start timestamp goes stale across natural breaks (sleep, weekends, lunch). Keep the previous anchor in mind so "yesterday" resolves against when the last exchange actually happened, not against a guess. The user should never have to explain that it's the next day. Also, periodically run the date command while in active conversation to keep it fresh.
 
 ## Coding Standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### July
 
+**Time awareness rule:**
+
+- CLAUDE.md gains a top-of-file rule: on return-from-silence signals ("I'm back", "morning!!") or relative dates ("today", "yesterday"), run `date` and re-anchor before reasoning about time, keeping the previous anchor so relative references resolve against when the last exchange actually happened. Sessions span sleep/weekend breaks; the user shouldn't have to announce that it's the next day
+
 **Standards MCP check + Coding Standards section:**
 
 - CLAUDE.md `Code Style` renamed to `Coding Standards` and gains the rule: when the standards MCP is connected, newly written code gets checked against the relevant standards while writing or right after push, in parallel with tests/CI (delegable to an arm). Catches standards violations locally instead of waiting a full cycle for AI review to bounce them back


### PR DESCRIPTION
## What

Adds a `## Time awareness` section near the top of CLAUDE.md: when the user returns after a quiet gap ("I'm back", "morning!!") or uses a relative date ("today", "yesterday", "Monday"), run `date` first and re-anchor, keeping the previous anchor in mind so relative references resolve against when the last exchange actually happened.

## Why

Sessions outlive the clock they started on — the start timestamp goes stale across sleep, weekends, and lunch. Without this, "yesterday" resolves against a stale date and the user has to explain what day it is.

## Verify

Two files: the new CLAUDE.md section, and the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)