### PR TITLE
feat(claude): justify ANY unsafe change in PR descriptions, label or not

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,7 @@ When cwd is an org-style directory (e.g. `~/workspace/<org-or-user>/`) containin
 - **Push early, verify in parallel**: commit → lint/format (quick, cheap) → push → THEN slow checks (typecheck, tests, standards check) in the background. CI runs in parallel; if local checks catch something first, fix and re-push asap.
 - PR description fresh and accurate on every push
 - **PR labels**: apply the correct labels when the repo has them (e.g. `expect-breaking-changes`, `allow-unsafe-migrations`). Any label that waives a safety gate MUST come with context in the PR description — what it permits and the reasoning why it's OK here.
+- **Justify ANY unsafe change, label or not**: breaking changes, risky migrations, backwards-incompatible anything — the PR description explains the risk and why it's acceptable, even when no label exists to flag it. The reviewer gets the context either way.
 - Always work in PRs, never push to main unless asked
 - Signed commits MANDATORY
 - **Never push tags** — user handles tags/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 **PR labels rule:**
 
 - CLAUDE.md Git & GitHub gains: apply the repo's labels when creating PRs (e.g. `expect-breaking-changes`, `allow-unsafe-migrations`), and any label that waives a safety gate must be justified in the PR description — what it permits and why it's OK for this change. A bare waiver label tells the reviewer nothing
+- Companion rule: ANY unsafe change (breaking, risky migration, backwards-incompatible) gets justified in the PR description even when no label exists to flag it — the reviewer gets the risk context either way
 
 **Time awareness rule:**
 


### PR DESCRIPTION
## What

Companion bullet to the PR-labels rule from #69: ANY unsafe change — breaking, risky migration, backwards-incompatible — gets the risk and why it's acceptable explained in the PR description, even when no label exists to flag it.

## Why

This bullet was amended onto the #69 branch but the merge raced the force-push, so main got the labels rule without the label-independent half. The absence of a label system shouldn't mean the absence of justification.

## Verify

Two files: one CLAUDE.md bullet, one CHANGELOG line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)