### PR TITLE
feat(wt): gh-aware wtclean, dedupe the wt-* plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 **wt-\* plugins: dead paths and drifted copies:**
 
-- The plugin split (#76) left `scripts/wt-picker` and `scripts/wt-preview` behind. The zellij `alt+w` binding and the `wtt` completion preview had been pointing at nothing ever since — the latter single-quoted, so `$word` never expanded either. herdr's popups were bound to `wtpr-pick` and `wth-pick`, neither of which had ever existed
+- The plugin split (#76) left `scripts/wt-picker` and `scripts/wt-preview` behind. The zellij `alt+w` binding and the `wtt` completion preview had been pointing at nothing ever since — the latter single-quoted, so `$word` never expanded either
 - `wt-shell` counted unpushed commits with `@{upstream}..HEAD`. A branch created with `-b` and never pushed has no upstream, so git errored and the count came back zero — reading as clean in the exact case where commits were about to be lost. `wtt -b foo`, commit, close the tab, gone. Now falls back to the remote default branch
 - `wt-picker` carried its own copy of the create path — fetch plus the three-way `worktree add` fallback — and it had drifted from `wt-core`'s. It shells into the plugin functions now. Parsing `worktree list --porcelain` went from four copies to one `wt-list` script
 - `wtpr`/`wti` were welded to herdr, so the zellij backend couldn't open a PR at all. Ref parsing, the PR-vs-issue probe, fork fetching via `refs/pull/N/head` and slugging moved to `wt-core`; a backend is now two one-line bindings and gets `wttpr`/`wtti`/`wttpr-pick` for nothing. wt-herdr: 140 lines → 41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**Worktree cleanup asks GitHub, not git:**
+
+- `git branch --merged` never reclaimed anything, because everything is squash-merged: the local branch shares no commit with what actually landed, so git calls it unmerged forever. `wtclean` now asks `gh` for PR state — merged or closed means the worktree and its branch go, along with orphaned branches whose worktree is already gone. Without `gh` a deleted upstream stands in, which means the same thing in practice
+- One `gh pr list` up front instead of a query per branch. A dozen worktrees is a second, not a minute — it's meant to run from cron
+- Five verbs collapsed to two. `wtd` was `wtrm` with a different argument, `wtp` was an alias for `git worktree prune`, and `wtpb` skipped every branch it existed to prune, because `-d` refuses on a squash-merged branch
+- Dirty worktrees, the one you're standing in, and detached checkouts are never touched. `-n` dry-runs — and did not, on the first cut, which cost two already-merged branches
+
+**wt-\* plugins: dead paths and drifted copies:**
+
+- The plugin split (#76) left `scripts/wt-picker` and `scripts/wt-preview` behind. The zellij `alt+w` binding and the `wtt` completion preview had been pointing at nothing ever since — the latter single-quoted, so `$word` never expanded either. herdr's popups were bound to `wtpr-pick` and `wth-pick`, neither of which had ever existed
+- `wt-shell` counted unpushed commits with `@{upstream}..HEAD`. A branch created with `-b` and never pushed has no upstream, so git errored and the count came back zero — reading as clean in the exact case where commits were about to be lost. `wtt -b foo`, commit, close the tab, gone. Now falls back to the remote default branch
+- `wt-picker` carried its own copy of the create path — fetch plus the three-way `worktree add` fallback — and it had drifted from `wt-core`'s. It shells into the plugin functions now. Parsing `worktree list --porcelain` went from four copies to one `wt-list` script
+- `wtpr`/`wti` were welded to herdr, so the zellij backend couldn't open a PR at all. Ref parsing, the PR-vs-issue probe, fork fetching via `refs/pull/N/head` and slugging moved to `wt-core`; a backend is now two one-line bindings and gets `wttpr`/`wtti`/`wttpr-pick` for nothing. wt-herdr: 140 lines → 41
+- `_wt_repo_root` aborted on an unmatched glob instead of reporting no local checkout, and `wtrm`'s zellij tab close fired on whichever tab was current rather than the worktree's
+
 **Zed worktree scan — `node_modules` excluded:**
 
 - Zed's own diagnostics reported **16,020,592 tracked entries against 15,193 visible** in one monorepo checkout, with the process resident at ~18 GB. Excluding `**/node_modules` took it to 15,265 entries / 0.34 GB — a ~1000× drop in tracked entries and ~40× in memory, and the file picker went back to being instant

--- a/README.md
+++ b/README.md
@@ -47,15 +47,14 @@ Run `upd` (or `converge`) anytime to update everything. Tasks that need gh auth 
 - `git conf-dir` — Set per-directory git config (email, signing, etc.)
 - `fm` / `fr` — Fuzzy merge/rebase with fzf
 
-**Worktrees** (`wt*`) — git worktree management with Zellij integration. Worktrees live in `<repo-parent>/worktrees/<repo>/<name>/` — outside the repo so editors don't recurse into them.
+**Worktrees** (`wt*`) — git worktree management, as local zsh plugins under `zsh-plugins/`: `wt-core` plus a backend per multiplexer (`wt-herdr`, `wt-zellij`). Worktrees live in `<repo-parent>/worktrees/<repo>/<name>/` — outside the repo so editors don't recurse into them.
 
 - `wt` / `wt <name>` — Upsert worktree + cd (fzf picker with no args)
-- `wtt` / `wtt <name>` — Upsert worktree + Zellij tab (fzf picker with no args)
-- `wt -b <name>` / `wtt -b <name>` — Branch from current HEAD instead of origin/main
-- `wtpr <PR>` — Upsert worktree + tab for a GitHub PR (handles forks)
-- `wtrm` — Remove current worktree (cd to root + cleanup)
-- `wtd <name>` — Remove worktree by name + delete local branch
-- `wtp` — Prune stale worktree refs
+- `wtt` / `wth` — Same, opening a Zellij tab / herdr workspace instead
+- `wt -b <name>` — Branch from current HEAD instead of origin/main
+- `wtpr <n|url>` — Worktree for a GitHub PR **or** issue (handles forks); `wti` for issues only, `wtpr-pick` to fzf over both
+- `wtrm [name]` — Remove the worktree you're in (or a named one) + its branch
+- `wtclean [-n]` — GC worktrees and branches whose PR is merged or closed, per `gh`. Keeps anything dirty
 
 **Media**
 

--- a/config.d/herdr/config.toml
+++ b/config.d/herdr/config.toml
@@ -138,7 +138,7 @@ height = "60%"
 [[keys.command]]
 key = "alt+w"
 type = "popup"
-command = "zsh -ic 'wth'"
+command = "zsh -ic 'wth-pick'"
 description = "worktree picker (per-org paths)"
 width = "80%"
 height = "70%"

--- a/config.d/herdr/config.toml
+++ b/config.d/herdr/config.toml
@@ -138,7 +138,7 @@ height = "60%"
 [[keys.command]]
 key = "alt+w"
 type = "popup"
-command = "zsh -ic 'wth-pick'"
+command = "zsh -ic 'wth'"
 description = "worktree picker (per-org paths)"
 width = "80%"
 height = "70%"

--- a/config.d/zellij/config.kdl
+++ b/config.d/zellij/config.kdl
@@ -175,7 +175,7 @@ keybinds clear-defaults=true {
         bind "Alt Shift p" { ToggleGroupMarking; }
         bind "Ctrl q" { Quit; }
         bind "Alt w" {
-            Run "bash" "-c" "$HOME/.dotfiles/scripts/wt-picker" {
+            Run "bash" "-c" "$HOME/.dotfiles/zsh-plugins/wt-zellij/bin/wt-picker" {
                 floating true
                 hold_on_close false
                 x "5%"

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -60,7 +60,6 @@ the new pane — pass `:` to skip):
 ```zsh
 wtmpr()      { _wt_pr      _wt_mine _wt_mine_prime "$@"; }  # PR or issue
 wtmi()       { _wt_issue   _wt_mine _wt_mine_prime "$@"; }  # issue -> <n>-<slug>
-wtmpr-pick() { _wt_pr_pick _wt_mine _wt_mine_prime; }       # fzf over both
 ```
 
 Ref parsing, the PR/issue probe, fork fetching and slugging all live here, so a

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -21,13 +21,26 @@ local = "~/.dotfiles/zsh-plugins/wt-core"
 | Command | Does |
 | --- | --- |
 | `wt [-b] <name> [base]` | upsert worktree, `cd` into it. No args: fzf picker |
-| `wtd <name>` | remove worktree and its branch |
-| `wtrm [name]` | remove the worktree you're in (or a named one) |
-| `wtclean` | remove clean worktrees, force-remove agent ones, keep dirty |
-| `wtpb` | prune branches whose worktree is gone |
-| `wtp` | `git worktree prune -v` |
+| `wtrm [name]` | remove the worktree you're in (or a named one), branch included |
+| `wtclean [-n]` | garbage-collect worktrees and branches against GitHub |
 
-`-b` branches from `HEAD` instead of the remote default.
+`-b` branches from `HEAD` instead of the remote default. `-n` is a dry run.
+
+## wtclean
+
+Everything gets squash-merged, so a merged branch still looks unmerged to
+`git branch --merged` and nothing is ever reclaimed. GitHub's PR state is the
+only reliable signal, so `wtclean` asks `gh`: a worktree whose PR is **merged or
+closed** goes, branch included, along with orphaned branches whose worktree is
+already gone. Without `gh` it falls back to a deleted upstream, which means the
+same thing in practice.
+
+Uncommitted changes always win — a dirty worktree is never touched, nor is the
+one you're standing in. Agent worktrees under `.claude/worktrees` are session
+detritus and always go.
+
+One `gh pr list` up front rather than a query per branch, which is the
+difference between a second and a minute. Safe to run from cron.
 
 ## Extending
 
@@ -39,6 +52,26 @@ wtm() { _wt_core _wt_mine "$@"; }
 ```
 
 `_wt_core` handles the picker, upsert and creation; the backend only opens.
+
+The GitHub entry points take that same function plus a `prime_fn`, which is
+handed the issue number after the worktree opens (for sending a command into
+the new pane — pass `:` to skip):
+
+```zsh
+wtmpr()      { _wt_pr      _wt_mine _wt_mine_prime "$@"; }  # PR or issue
+wtmi()       { _wt_issue   _wt_mine _wt_mine_prime "$@"; }  # issue -> <n>-<slug>
+wtmpr-pick() { _wt_pr_pick _wt_mine _wt_mine_prime; }       # fzf over both
+```
+
+Ref parsing, the PR/issue probe, fork fetching and slugging all live here, so a
+backend is only ever the two functions above.
+
+## Bin
+
+`wt-list` prints `branch<TAB>path` per worktree, or the path of a named branch.
+Parsing `worktree list --porcelain` lived in four places and drifted; this is
+the one copy. `wt-preview` renders the fzf preview: PR details if there's a PR,
+otherwise log plus tree.
 
 ## Exports
 

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Emits "branch<TAB>path", one worktree per line. With an argument, prints only
+# the path of that branch. Parsing `worktree list --porcelain` lived in four
+# places and drifted; this is the one copy.
+# Branch is empty for detached worktrees — callers that display it filter those.
+set -o pipefail
+
+git worktree list --porcelain 2>/dev/null | awk -v want="${1:-}" '
+  function emit() {
+    if (want == "") printf "%s\t%s\n", b, p
+    else if (b == want) print p
+  }
+  /^worktree /{ p = $2; b = "" }
+  /^branch /{ b = $2; sub("refs/heads/", "", b) }
+  /^$/{ if (p != "") emit(); p = "" }
+  END { if (p != "") emit() }
+'

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -5,8 +5,7 @@
 set -euo pipefail
 
 branch="${1%%$'\t'*}"
-path=$(git worktree list --porcelain 2>/dev/null \
-  | awk -v b="refs/heads/$branch" '/^worktree /{ wt=$2 } /^branch /{ if($2==b) print wt }')
+path=$("$(dirname "${BASH_SOURCE[0]}")/wt-list" "$branch")
 [[ -n $path ]] || exit 0
 
 # Try PR view first — shows title, status, checks, reviewers

--- a/zsh-plugins/wt-core/wt-core.plugin.zsh
+++ b/zsh-plugins/wt-core/wt-core.plugin.zsh
@@ -237,56 +237,6 @@ _wt_issue() {
   "$prime_fn" "$num"
 }
 
-# ── _wt_pr_pick <go_fn> <prime_fn> ──────────────────────────────────
-# fzf over open PRs and issues, or paste any reference _wt_pr understands
-# (URL / owner/repo#N / number). --print-query returns what was typed when it
-# matches no row, so a pasted URL falls straight through — which also means it
-# works for repos other than the one the picker was opened in.
-_wt_pr_pick() {
-  command -v gh  >/dev/null || { echo "gh not found"; read -k1; return 1; }
-  command -v fzf >/dev/null || { echo "fzf not found"; read -k1; return 1; }
-
-  # Author is its own column so fzf can filter on it; the query starts on your
-  # own login, so it opens showing your work and backspacing reveals everyone's.
-  local me=${GH_LOGIN:-$(gh api user -q .login 2>/dev/null)}
-
-  local out
-  out=$({
-    gh pr list --limit 200 --json number,author,title,isDraft \
-      -q '.[] | "\(.number)\t@\(.author.login)\tPR\t\(if .isDraft then "[draft] " else "" end)\(.title)"' 2>/dev/null
-    gh issue list --limit 200 --json number,author,title \
-      -q '.[] | "\(.number)\t@\(.author.login)\tissue\t\(.title)"' 2>/dev/null
-  } | column -t -s $'\t' \
-    | fzf --print-query --query="$me " --prompt='PR / issue / URL > ' \
-          --height=100% --border \
-          --header='enter on a row · clear the query for all authors · or paste a url / owner/repo#N' \
-          --preview='gh pr view {1} --comments 2>/dev/null || gh issue view {1} --comments 2>/dev/null')
-
-  # line 1 is the query, line 2 the selected row (absent when nothing matched).
-  # Must split into a real array — ${${(f)out}[1]} indexes characters, not lines.
-  local -a lines=("${(@f)out}")
-  local query=${lines[1]} sel=${lines[2]} ref
-  if [[ -n $sel ]]; then
-    ref=${sel%% *}
-  elif [[ $query =~ '(https?://[^[:space:]]+)' ]]; then
-    ref=$match[1]                      # a paste lands after the author query
-  elif [[ $query =~ '([^[:space:]/]+/[^[:space:]#]+#[0-9]+)' ]]; then
-    ref=$match[1]
-  elif [[ $query =~ '([0-9]+)' ]]; then
-    ref=$match[1]
-  fi
-  [[ -n $ref ]] || return 0
-
-  # A herdr popup dies the moment this returns, so hold it open on failure —
-  # otherwise the error flashes and vanishes.
-  if ! _wt_pr "$1" "$2" "$ref"; then
-    print -u2 "\nfailed for: $ref"
-    print -u2 "any key to close"
-    read -k1
-    return 1
-  fi
-}
-
 # ── wtrm [name] ─────────────────────────────────────────────────────
 # No args: remove the worktree you're currently inside, cd to repo root
 wtrm() {

--- a/zsh-plugins/wt-core/wt-core.plugin.zsh
+++ b/zsh-plugins/wt-core/wt-core.plugin.zsh
@@ -36,10 +36,10 @@ _wt_ensure_dir() {
   [[ -d $dir ]] || mkdir -p "$dir"
 }
 
-_wt_find() {
-  git worktree list --porcelain 2>/dev/null \
-    | awk -v b="refs/heads/$1" '/^worktree /{ wt=$2 } /^branch /{ if($2==b) print wt }'
-}
+_wt_find() { "$WT_CORE_BIN"/wt-list "$1"; }
+
+# branch<TAB>path, minus detached worktrees — picker fodder.
+_wt_named() { "$WT_CORE_BIN"/wt-list | awk -F'\t' '$1 != ""'; }
 
 _wt_cd() { cd "$2"; }
 
@@ -66,8 +66,7 @@ _wt_core() {
       return
     fi
     local output query selected
-    output=$(git worktree list --porcelain \
-      | awk '/^worktree /{ path=$2 } /^branch /{ branch=$2; sub("refs/heads/","",branch); printf "%s\t%s\n", branch, path }' \
+    output=$(_wt_named \
       | fzf --ansi --reverse --delimiter=$'\t' --with-nth=1 \
              --header="worktrees (type new name to create)" \
              --popup='center,90%,90%' --preview "$_wt_fzf_preview" --preview-window='right:70%' \
@@ -136,117 +135,306 @@ wt()  { _wt_core _wt_cd "$@"; }
 # ~/workspace, so <org>/<repo> lives at the same path.
 _wt_repo_root() {
   local owner=$1 repo=$2 p
-  for p in "$HOME/workspace/$owner/$repo" "$HOME/workspace"/*/"$repo"; do
+  # (N) or a miss aborts the loop with "no matches found" before the message below
+  for p in "$HOME/workspace/$owner/$repo" "$HOME/workspace"/*/"$repo"(N); do
     [[ -d $p/.git ]] && { echo "$p"; return 0; }
   done
   echo "no local checkout for $owner/$repo under ~/workspace" >&2
   return 1
 }
 
-# ── wtd <name> ──────────────────────────────────────────────────────
-wtd() {
-  local name=$1
-  [[ -z $name ]] && { echo "usage: wtd <name>"; return 1; }
-  local wt=$(_wt_path "$name")
-  [[ -d $wt ]] || { echo "no worktree at $wt"; return 1; }
-  [[ "$PWD" == "$wt"* ]] && { echo "cd out of the worktree first"; return 1; }
-  git worktree remove "$wt" || return 1
-  git branch -d "$name" 2>/dev/null
-  echo "removed: $name"
+# ── GitHub refs ─────────────────────────────────────────────────────
+# <n> | <url> | owner/repo#<n> → "owner<TAB>repo<TAB>num<TAB>root". A bare
+# number resolves against the current repo; qualified forms find the checkout
+# under ~/workspace. owner/repo stay empty for the bare form.
+_wt_ref_parse() {
+  local arg=$1 owner repo num root
+  if [[ $arg =~ '^https?://[^/]+/([^/]+)/([^/]+)/(pull|issues)/([0-9]+)' ]]; then
+    owner=$match[1] repo=$match[2] num=$match[4]
+    root=$(_wt_repo_root "$owner" "$repo") || return 1
+  elif [[ $arg =~ '^([^/]+)/([^#]+)#([0-9]+)$' ]]; then
+    owner=$match[1] repo=$match[2] num=$match[3]
+    root=$(_wt_repo_root "$owner" "$repo") || return 1
+  elif [[ $arg == <-> ]]; then
+    num=$arg
+    root=$(_wt_root) || { echo "not in a git repo — pass a url" >&2; return 1; }
+  else
+    echo "unrecognised reference: $arg" >&2; return 1
+  fi
+  print -r -- "$owner"$'\t'"$repo"$'\t'"$num"$'\t'"$root"
+}
+
+# gh against an explicit repo when the ref named one, else against root's remote
+_wt_gh() {
+  local root=$1 owner=$2 repo=$3; shift 3
+  if [[ -n $owner ]]; then
+    gh "$@" --repo "$owner/$repo"
+  else
+    (builtin cd "$root" && gh "$@")
+  fi
+}
+
+# Slug matching the convention already used across these repos:
+# <issue-number>-<kebab-title>, e.g. 931-rating-reconciliation
+_wt_issue_slug() {
+  local n=$1 title=$2 slug
+  slug=${title:l}
+  slug=${slug//[^a-z0-9]/-}          # non-alnum -> dash
+  while [[ $slug == *--* ]]; do slug=${slug//--/-}; done
+  slug=${slug##-}; slug=${slug%%-}
+  slug=${slug[1,48]}; slug=${slug%%-}
+  print -r -- "${n}-${slug}"
+}
+
+# ── _wt_pr <go_fn> <prime_fn> <ref> ─────────────────────────────────
+# Takes a PR or an issue: a URL disambiguates itself (/pull/ vs /issues/), and
+# a bare number is probed — GitHub numbers both from one sequence, and
+# `gh pr view` only resolves PRs, so a failure means issue.
+_wt_pr() {
+  local go_fn=$1 prime_fn=$2 arg=$3
+  command -v gh >/dev/null || { echo "gh not found"; return 1; }
+  [[ -z $arg ]] && { echo "usage: <number|url|owner/repo#N>  (PR or issue)"; return 1; }
+  [[ $arg == *"/issues/"* ]] && { _wt_issue "$go_fn" "$prime_fn" "$arg"; return; }
+
+  local parsed; parsed=$(_wt_ref_parse "$arg") || return 1
+  local owner repo num root
+  IFS=$'\t' read -r owner repo num root <<< "$parsed"
+
+  _wt_gh "$root" "$owner" "$repo" pr view "$num" --json number -q .number >/dev/null 2>&1 \
+    || { _wt_issue "$go_fn" "$prime_fn" "$arg"; return; }
+
+  local branch
+  branch=$(_wt_gh "$root" "$owner" "$repo" pr view "$num" --json headRefName -q .headRefName)
+  [[ -n $branch ]] || { echo "could not resolve PR #$num"; return 1; }
+
+  # PR head may not exist locally; refs/pull works for forks too
+  git -C "$root" fetch origin "pull/${num}/head:${branch}" --quiet 2>/dev/null \
+    || git -C "$root" fetch origin "$branch" --quiet 2>/dev/null
+
+  (builtin cd "$root" && _wt_core "$go_fn" "$branch")
+}
+
+# ── _wt_issue <go_fn> <prime_fn> <ref> ──────────────────────────────
+# Worktree named <n>-<slug>, then prime_fn gets the issue number to hand off to
+# claude. `claude <prompt>` starts interactively — -p is what makes it batch —
+# so the session that lands in the pane is live.
+_wt_issue() {
+  local go_fn=$1 prime_fn=$2 arg=$3
+  command -v gh >/dev/null || { echo "gh not found"; return 1; }
+  [[ -z $arg ]] && { echo "usage: <issue-number|issue-url>"; return 1; }
+
+  local parsed; parsed=$(_wt_ref_parse "$arg") || return 1
+  local owner repo num root
+  IFS=$'\t' read -r owner repo num root <<< "$parsed"
+
+  local title
+  title=$(_wt_gh "$root" "$owner" "$repo" issue view "$num" --json title -q .title)
+  [[ -n $title ]] || { echo "could not resolve issue #$num"; return 1; }
+
+  local slug=$(_wt_issue_slug "$num" "$title")
+  print -r -- "→ $slug"
+  (builtin cd "$root" && _wt_core "$go_fn" "$slug") || return 1
+  "$prime_fn" "$num"
+}
+
+# ── _wt_pr_pick <go_fn> <prime_fn> ──────────────────────────────────
+# fzf over open PRs and issues, or paste any reference _wt_pr understands
+# (URL / owner/repo#N / number). --print-query returns what was typed when it
+# matches no row, so a pasted URL falls straight through — which also means it
+# works for repos other than the one the picker was opened in.
+_wt_pr_pick() {
+  command -v gh  >/dev/null || { echo "gh not found"; read -k1; return 1; }
+  command -v fzf >/dev/null || { echo "fzf not found"; read -k1; return 1; }
+
+  # Author is its own column so fzf can filter on it; the query starts on your
+  # own login, so it opens showing your work and backspacing reveals everyone's.
+  local me=${GH_LOGIN:-$(gh api user -q .login 2>/dev/null)}
+
+  local out
+  out=$({
+    gh pr list --limit 200 --json number,author,title,isDraft \
+      -q '.[] | "\(.number)\t@\(.author.login)\tPR\t\(if .isDraft then "[draft] " else "" end)\(.title)"' 2>/dev/null
+    gh issue list --limit 200 --json number,author,title \
+      -q '.[] | "\(.number)\t@\(.author.login)\tissue\t\(.title)"' 2>/dev/null
+  } | column -t -s $'\t' \
+    | fzf --print-query --query="$me " --prompt='PR / issue / URL > ' \
+          --height=100% --border \
+          --header='enter on a row · clear the query for all authors · or paste a url / owner/repo#N' \
+          --preview='gh pr view {1} --comments 2>/dev/null || gh issue view {1} --comments 2>/dev/null')
+
+  # line 1 is the query, line 2 the selected row (absent when nothing matched).
+  # Must split into a real array — ${${(f)out}[1]} indexes characters, not lines.
+  local -a lines=("${(@f)out}")
+  local query=${lines[1]} sel=${lines[2]} ref
+  if [[ -n $sel ]]; then
+    ref=${sel%% *}
+  elif [[ $query =~ '(https?://[^[:space:]]+)' ]]; then
+    ref=$match[1]                      # a paste lands after the author query
+  elif [[ $query =~ '([^[:space:]/]+/[^[:space:]#]+#[0-9]+)' ]]; then
+    ref=$match[1]
+  elif [[ $query =~ '([0-9]+)' ]]; then
+    ref=$match[1]
+  fi
+  [[ -n $ref ]] || return 0
+
+  # A herdr popup dies the moment this returns, so hold it open on failure —
+  # otherwise the error flashes and vanishes.
+  if ! _wt_pr "$1" "$2" "$ref"; then
+    print -u2 "\nfailed for: $ref"
+    print -u2 "any key to close"
+    read -k1
+    return 1
+  fi
 }
 
 # ── wtrm [name] ─────────────────────────────────────────────────────
 # No args: remove the worktree you're currently inside, cd to repo root
 wtrm() {
   local root=$(_wt_root)
+  local here=$(git rev-parse --show-toplevel 2>/dev/null)
   local name wt
 
   if [[ -n $1 ]]; then
     name=$1
-    wt=$(_wt_path "$name")
+    # Registered location wins: a worktree moved off the convention still dies.
+    wt=$(_wt_find "$name"); [[ -n $wt ]] || wt=$(_wt_path "$name")
   else
-    # Detect current worktree
-    wt=$(git rev-parse --show-toplevel 2>/dev/null)
-    [[ $wt == "$root" ]] && { echo "not inside a worktree"; return 1; }
+    wt=$here
+    [[ -z $wt || $wt == "$root" ]] && { echo "not inside a worktree"; return 1; }
     name=$(basename "$wt")
   fi
 
   [[ -d $wt ]] || { echo "no worktree at $wt"; return 1; }
-  cd "$root"
+  builtin cd "$root"
   git worktree remove "$wt" || return 1
-  git branch -d "$name" 2>/dev/null
+  # -d refuses on squash-merged branches, which is most of them.
+  if ! git branch -d "$name" 2>/dev/null; then
+    local repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+    case $(_wt_pr_state "$name" "$repo") in
+      MERGED|CLOSED) git branch -D "$name" 2>/dev/null ;;
+    esac
+  fi
   echo "removed: $name"
 
-  # Close the zellij tab if we're inside one named after this worktree
-  if [[ -n $ZELLIJ ]] && zellij action query-tab-names 2>/dev/null | grep -qxF "$name"; then
+  # Only when the tab being closed is the one we were standing in — otherwise
+  # close-tab kills whichever tab is current, which is the wrong one.
+  if [[ -n $ZELLIJ && $here == "$wt" ]]; then
     zellij action close-tab
   fi
 }
 
-# ── wtp ─────────────────────────────────────────────────────────────
-alias wtp='git worktree prune -v'
+# ── wtclean [-n] ────────────────────────────────────────────────────
+# Everything is squash-merged, so a merged branch still looks unmerged to
+# `git branch --merged` and nothing ever gets reclaimed. GitHub's PR state is
+# the only reliable signal; without gh, a deleted upstream stands in for it.
+# Uncommitted work always wins — a dirty worktree is never touched.
 
-# ── wtclean — housekeep worktrees: prune stale registry, nuke agent leftovers, leave dirty ones alone
-wtclean() {
-  local root=$(_wt_root) wt removed=0 kept=0
-  [[ -z $root ]] && { echo "not in a git repo"; return 1; }
-  while IFS= read -r wt; do
-    [[ -z $wt || $wt == "$root" ]] && continue
-    git worktree unlock "$wt" 2>/dev/null
-    # Agent worktrees are session detritus — always force.
-    if [[ $wt == */.claude/worktrees/* ]]; then
-      if git worktree remove --force "$wt" 2>/dev/null; then
-        echo "  removed (agent): $wt"
-        ((removed++))
-      fi
-      continue
-    fi
-    # Real worktrees: only remove if clean. Refuses on uncommitted changes / current cwd.
-    if git worktree remove "$wt" 2>/dev/null; then
-      echo "  removed: $wt"
-      ((removed++))
-    else
-      echo "  kept:    $wt (dirty or in-use — use 'wtrm $(basename "$wt")' to force)"
-      ((kept++))
-    fi
-  done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{ print $2 }')
-  git worktree prune -v
-  echo "wtclean: removed $removed, kept $kept"
+# One list call up front — a query per branch turns a sweep into a minute of
+# round trips. Branches past the window fall through to a direct query.
+typeset -gA _wt_prs
+_wt_pr_cache() {
+  local repo=$1 branch state
+  _wt_prs=()
+  [[ -z $repo ]] && return
+  while IFS=$'\t' read -r branch state; do
+    [[ -n $branch ]] && _wt_prs[$branch]=$state
+  done < <(gh pr list -R "$repo" --state all --limit 200 \
+    --json headRefName,state --jq '.[] | [.headRefName, .state] | @tsv' 2>/dev/null)
 }
 
-# ── wtpb — prune orphaned worktree branches ─────────────────────────
-wtpb() {
-  local root=$(_wt_root)
-  local default=$(_wt_base)
-  local pruned=0
-  # Get branches that have active worktrees
-  local -a wt_branches
-  wt_branches=(${(f)"$(git worktree list --porcelain 2>/dev/null \
-    | awk '/^branch /{ b=$2; sub("refs/heads/","",b); print b }')"})
+# MERGED | CLOSED | OPEN | NONE
+_wt_pr_state() {
+  local branch=$1 repo=$2 state=${_wt_prs[$1]}
+  [[ -n $state ]] && { echo "$state"; return }
+  if [[ -n $repo ]]; then
+    state=$(gh pr list -R "$repo" --head "$branch" --state all --limit 1 \
+      --json state --jq '.[0].state // "NONE"' 2>/dev/null)
+    [[ -n $state ]] && { echo "$state"; return }
+  fi
+  [[ $(git for-each-ref --format='%(upstream:track)' "refs/heads/$branch") == *gone* ]] \
+    && echo MERGED || echo NONE
+}
 
-  git for-each-ref --format='%(refname:short)' refs/heads/ | while read -r branch; do
-    [[ $branch == "$default" ]] && continue
-    # Skip if branch has an active worktree
-    if (( ${wt_branches[(Ie)$branch]} )); then
+wtclean() {
+  local root=$(_wt_root)
+  [[ -z $root ]] && { echo "not in a git repo"; return 1; }
+  local dry=0
+  [[ $1 == -n || $1 == --dry-run ]] && dry=1
+
+  local here=$(git rev-parse --show-toplevel 2>/dev/null)
+  local repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+  [[ -z $repo ]] && echo "  no gh — falling back to deleted-upstream detection"
+  git -C "$root" fetch --prune --quiet 2>/dev/null
+  _wt_pr_cache "$repo"
+
+  # Split by hand: tab is IFS-whitespace, so `read` would collapse the empty
+  # branch field of a detached worktree and shift the path into it.
+  local line wt branch label state removed=0 kept=0
+  while IFS= read -r line; do
+    branch=${line%%$'\t'*}
+    wt=${line#*$'\t'}
+    [[ -z $wt || $wt == "$root" ]] && continue
+    label=${branch:-$wt}
+    git worktree unlock "$wt" 2>/dev/null
+
+    # Agent worktrees are session detritus — always force.
+    if [[ $wt == */.claude/worktrees/* ]]; then
+      (( dry )) && { echo "  would nuke (agent): $wt"; continue }
+      git worktree remove --force "$wt" 2>/dev/null \
+        && { echo "  removed (agent): $wt"; ((removed++)) }
       continue
     fi
-    # Check if worktree dir exists at expected path
-    local wt=$(_wt_path "$branch")
-    if [[ ! -d $wt ]]; then
-      git branch -d "$branch" 2>/dev/null && {
-        echo "  pruned: $branch"
-        pruned=$((pruned + 1))
-      } || echo "  skipped: $branch (unmerged — use -D to force)"
+
+    [[ $wt == "$here" ]] && { echo "  kept:    $label (you're in it)"; ((kept++)); continue }
+    if [[ -n $(git -C "$wt" status --porcelain 2>/dev/null) ]]; then
+      echo "  kept:    $label (uncommitted changes)"; ((kept++)); continue
+    fi
+    [[ -z $branch ]] && { echo "  kept:    $label (detached)"; ((kept++)); continue }
+
+    state=$(_wt_pr_state "$branch" "$repo")
+    case $state in
+      MERGED|CLOSED)
+        (( dry )) && { echo "  would remove: $branch (PR $state)"; continue }
+        if git worktree remove "$wt" 2>/dev/null; then
+          git -C "$root" branch -D "$branch" >/dev/null 2>&1
+          echo "  removed: $branch (PR $state)"; ((removed++))
+        else
+          echo "  kept:    $branch (in use)"; ((kept++))
+        fi ;;
+      OPEN) echo "  kept:    $branch (PR open)"; ((kept++)) ;;
+      *)    echo "  kept:    $branch (no PR)"; ((kept++)) ;;
+    esac
+  done < <("$WT_CORE_BIN"/wt-list)
+
+  # Branches whose worktree is already gone.
+  local base=$(_wt_base) b dropped=0
+  local -a live
+  live=(${(f)"$(_wt_named | cut -f1)"})
+  for b in ${(f)"$(git -C "$root" for-each-ref --format='%(refname:short)' refs/heads/)"}; do
+    [[ $b == "$base" ]] && continue
+    (( ${live[(Ie)$b]} )) && continue
+    state=$(_wt_pr_state "$b" "$repo")
+    if [[ $state == MERGED || $state == CLOSED ]]; then
+      (( dry )) && { echo "  would drop branch: $b (PR $state)"; continue }
+      git -C "$root" branch -D "$b" >/dev/null 2>&1 \
+        && { echo "  dropped branch: $b (PR $state)"; ((dropped++)) }
+    elif git -C "$root" merge-base --is-ancestor "$b" "origin/$base" 2>/dev/null; then
+      (( dry )) && { echo "  would drop branch: $b (merged)"; continue }
+      git -C "$root" branch -D "$b" >/dev/null 2>&1 \
+        && { echo "  dropped branch: $b (merged)"; ((dropped++)) }
     fi
   done
-  echo "pruned $pruned orphaned branch(es)"
+
+  local -a pruneargs=(-v); (( dry )) && pruneargs+=(-n)
+  git worktree prune $pruneargs
+  _wt_prs=()   # scoped to the run — a stale map misclassifies later calls
+  echo "wtclean: removed $removed, kept $kept, dropped $dropped branch(es)"
 }
 
 # ── Completions ─────────────────────────────────────────────────────
 _wt_branches() {
   local -a branches
-  branches=(${(f)"$(git worktree list --porcelain 2>/dev/null \
-    | awk '/^branch /{ b=$2; sub("refs/heads/","",b); print b }')"})
+  branches=(${(f)"$(_wt_named | cut -f1)"})
   _describe 'worktree' branches
 }
 
@@ -254,11 +442,13 @@ _wt_comp() {
   _arguments '--branch[derive from current branch]' '-b[derive from current branch]' \
     '1:branch:_wt_branches' '2:base:'
 }
-compdef _wt_comp wt
-compdef '_arguments "1:branch:_wt_branches"' wtd
-compdef '_arguments "1:branch:_wt_branches"' wtrm
+# compdef only exists once compinit has run. The picker sources this plugin
+# non-interactively to reuse its functions, and that must not spew errors.
+if (( $+functions[compdef] )); then
+  compdef _wt_comp wt
+  compdef '_arguments "1:branch:_wt_branches"' wtrm
+fi
 
 # ── fzf-tab previews ────────────────────────────────────────────────
 zstyle ':fzf-tab:complete:wt:*'   fzf-preview "$WT_CORE_BIN/wt-preview $word"
-zstyle ':fzf-tab:complete:wtd:*'  fzf-preview "$WT_CORE_BIN/wt-preview $word"
 zstyle ':fzf-tab:complete:wtrm:*' fzf-preview "$WT_CORE_BIN/wt-preview $word"

--- a/zsh-plugins/wt-herdr/README.md
+++ b/zsh-plugins/wt-herdr/README.md
@@ -35,10 +35,10 @@ local = "~/.dotfiles/zsh-plugins/wt-herdr"
 | `wth [-b] <name> [base]` | upsert worktree, open as a herdr workspace. No args: fzf picker |
 | `wtpr <n\|url\|owner/repo#n>` | PR **or** issue — a URL disambiguates, a bare number is probed |
 | `wti <n\|url\|owner/repo#n>` | worktree for a GitHub issue, named `<n>-<slug>`, with claude primed on `/ticket <n>` |
-| `wtpr-pick` | fzf over open PRs and issues, then as above |
 
-The logic lives in `wt-core`; these are bindings of `_wt_pr` / `_wt_issue` /
-`_wt_pr_pick` to the herdr backend, so the zellij backend has the same set.
+The logic lives in `wt-core`; these are bindings of `_wt_pr` / `_wt_issue` to
+the herdr backend, so the zellij backend has the same set. The popup wrappers
+(`wtpr-pick`, `wth-pick`, `wti-pick`) live in `config.d/zsh/conf.d/herdr.zsh`.
 
 `wtpr` is the single entry point for both. A URL disambiguates itself (`/pull/` vs `/issues/`); a bare number is ambiguous because GitHub numbers PRs and issues from one sequence, so it probes with `gh pr view` and falls through to `wti` when that fails.
 
@@ -53,8 +53,8 @@ owner is matched against directory names under `~/workspace`. Fetches via
 [[keys.command]]
 key = "alt+w"
 type = "popup"
-command = "zsh -ic 'wth'"
-description = "worktree picker"
+command = "zsh -ic 'wth-pick'"
+description = "worktree picker (per-org paths)"
 
 [[keys.command]]
 key = "alt+shift+p"
@@ -67,8 +67,10 @@ description = "PR / issue picker"
 starts an **interactive** session — `-p`/`--print` is what makes it batch — so
 the agent comes up live with the skill already invoked.
 
-Popups close the moment the command returns, so a wrapper that holds the window
-open on failure is worth having — otherwise errors flash past unseen.
+Popups close the moment the command returns, so the `-pick` wrappers in
+`config.d/zsh/conf.d/herdr.zsh` hold the window open on failure — otherwise
+errors flash past unseen. `wth-pick` also refuses early when the pane's cwd
+isn't a git repo; `wtpr-pick` doesn't, so there it looks like nothing happened.
 
 ## Gotcha
 

--- a/zsh-plugins/wt-herdr/README.md
+++ b/zsh-plugins/wt-herdr/README.md
@@ -35,6 +35,10 @@ local = "~/.dotfiles/zsh-plugins/wt-herdr"
 | `wth [-b] <name> [base]` | upsert worktree, open as a herdr workspace. No args: fzf picker |
 | `wtpr <n\|url\|owner/repo#n>` | PR **or** issue — a URL disambiguates, a bare number is probed |
 | `wti <n\|url\|owner/repo#n>` | worktree for a GitHub issue, named `<n>-<slug>`, with claude primed on `/ticket <n>` |
+| `wtpr-pick` | fzf over open PRs and issues, then as above |
+
+The logic lives in `wt-core`; these are bindings of `_wt_pr` / `_wt_issue` /
+`_wt_pr_pick` to the herdr backend, so the zellij backend has the same set.
 
 `wtpr` is the single entry point for both. A URL disambiguates itself (`/pull/` vs `/issues/`); a bare number is ambiguous because GitHub numbers PRs and issues from one sequence, so it probes with `gh pr view` and falls through to `wti` when that fails.
 
@@ -56,13 +60,7 @@ description = "worktree picker"
 key = "alt+shift+p"
 type = "popup"
 command = "zsh -ic 'wtpr-pick'"
-description = "PR picker"
-
-[[keys.command]]
-key = "alt+i"
-type = "popup"
-command = "zsh -ic 'wti-pick'"
-description = "issue picker"
+description = "PR / issue picker"
 ```
 
 `wti` primes the new pane by way of `herdr pane send-text`. `claude <prompt>`

--- a/zsh-plugins/wt-herdr/wt-herdr.plugin.zsh
+++ b/zsh-plugins/wt-herdr/wt-herdr.plugin.zsh
@@ -1,16 +1,13 @@
 # wt-herdr — herdr backend for wt-core.
-# herdr's own [worktrees] directory is a single global root with no {org}
-# placeholder, so it cannot express a per-org layout; paths come from
-# wt-core instead and herdr is only asked to open them.
-command -v herdr >/dev/null || return
-
-
 # herdr's own worktree management is unusable here: [worktrees] directory is a
 # single global root with no {org} placeholder, so it cannot reproduce the
 # per-org layout, and its default (~/.herdr/worktrees) sits outside ~/workspace
 # where the work mise.toml never applies — agents there would run on the
-# personal Claude profile. Paths computed here derive from the repo, so they
-# land in the right org tree and inherit the right profile.
+# personal Claude profile. Paths come from wt-core, which derives them from the
+# repo, so they land in the right org tree and inherit the right profile;
+# herdr is only asked to open them.
+command -v herdr >/dev/null || return
+
 # --cwd must be the main checkout: herdr rejects a linked worktree as the source
 # ("New and open worktree actions start from the repo parent workspace"). It
 # also reports errors as JSON with exit 0, so the payload has to be inspected.
@@ -29,112 +26,22 @@ _wt_herdr() {
 # No args: fzf picker over existing worktrees, or type a name to create one.
 wth() { _wt_core _wt_herdr "$@"; }
 
-# ── wtpr <PR-or-issue ref> ──────────────────────────────────────────
-# Takes a PR or an issue: a URL disambiguates itself (/pull/ vs /issues/), and
-# a bare number is probed — `gh pr view` fails on an issue, so a failure means
-# issue. Issues route to wti, which slugs the title and primes claude.
-wtpr() {
-  command -v gh >/dev/null || { echo "gh not found"; return 1; }
-  command -v herdr >/dev/null || { echo "herdr not found"; return 1; }
-  local arg=$1
-  [[ -z $arg ]] && { echo "usage: wtpr <number|url|owner/repo#N>  (PR or issue)"; return 1; }
-
-  [[ $arg == *"/issues/"* ]] && { wti "$arg"; return; }
-
-  local owner repo pr root
-  if [[ $arg =~ '^https?://[^/]+/([^/]+)/([^/]+)/pull/([0-9]+)' ]]; then
-    owner=$match[1] repo=$match[2] pr=$match[3]
-    root=$(_wt_repo_root "$owner" "$repo") || return 1
-  elif [[ $arg =~ '^([^/]+)/([^#]+)#([0-9]+)$' ]]; then
-    owner=$match[1] repo=$match[2] pr=$match[3]
-    root=$(_wt_repo_root "$owner" "$repo") || return 1
-  elif [[ $arg == <-> ]]; then
-    pr=$arg
-    root=$(_wt_root) || { echo "not in a git repo — pass a url"; return 1; }
-  else
-    echo "unrecognised reference: $arg"; return 1
-  fi
-
-  # GitHub numbers PRs and issues from one sequence, so a bare number is
-  # ambiguous. gh pr view only resolves PRs.
-  local probe
-  if [[ -n $owner ]]; then
-    probe=$(gh pr view "$pr" --repo "$owner/$repo" --json number -q .number 2>/dev/null)
-  else
-    probe=$(builtin cd "$root" && gh pr view "$pr" --json number -q .number 2>/dev/null)
-  fi
-  [[ -n $probe ]] || { wti "$arg"; return; }
-
-  local branch
-  if [[ -n $owner ]]; then
-    branch=$(gh pr view "$pr" --repo "$owner/$repo" --json headRefName -q .headRefName)
-  else
-    branch=$(cd "$root" && gh pr view "$pr" --json headRefName -q .headRefName)
-  fi
-  [[ -n $branch ]] || { echo "could not resolve PR #$pr"; return 1; }
-
-  # PR head may not exist locally; refs/pull works for forks too
-  git -C "$root" fetch origin "pull/${pr}/head:${branch}" --quiet 2>/dev/null \
-    || git -C "$root" fetch origin "$branch" --quiet 2>/dev/null
-
-  # herdr resolves the repo from --cwd and owns workspace creation
-  herdr worktree open --cwd "$root" --branch "$branch" --focus 2>/dev/null && return 0
-  herdr worktree create --cwd "$root" --branch "$branch" \
-    --path "$(dirname "$root")/worktrees/$(basename "$root")/${branch:t}" --focus
-}
-
-# Slug matching the convention already used across these repos:
-# <issue-number>-<kebab-title>, e.g. 931-rating-reconciliation
-_wt_issue_slug() {
-  local n=$1 title=$2 slug
-  slug=${title:l}
-  slug=${slug//[^a-z0-9]/-}          # non-alnum -> dash
-  while [[ $slug == *--* ]]; do slug=${slug//--/-}; done
-  slug=${slug##-}; slug=${slug%%-}
-  slug=${slug[1,48]}; slug=${slug%%-}
-  print -r -- "${n}-${slug}"
-}
-
-# ── wti <issue-number|issue-url> ────────────────────────────────────
-# Worktree named <n>-<slug> for a GitHub issue, opened as a herdr workspace,
-# with claude primed on /ticket <n>. `claude <prompt>` starts interactively —
-# -p is what makes it non-interactive — so the session is live, not batch.
-wti() {
-  command -v gh >/dev/null || { echo "gh not found"; return 1; }
-  local arg=$1
-  [[ -z $arg ]] && { echo "usage: wti <issue-number|issue-url>"; return 1; }
-
-  local owner repo num root
-  if [[ $arg =~ '^https?://[^/]+/([^/]+)/([^/]+)/issues/([0-9]+)' ]]; then
-    owner=$match[1] repo=$match[2] num=$match[3]
-    root=$(_wt_repo_root "$owner" "$repo") || return 1
-  elif [[ $arg =~ '^([^/]+)/([^#]+)#([0-9]+)$' ]]; then
-    owner=$match[1] repo=$match[2] num=$match[3]
-    root=$(_wt_repo_root "$owner" "$repo") || return 1
-  elif [[ $arg == <-> ]]; then
-    num=$arg
-    root=$(_wt_root) || { echo "not in a git repo — pass an issue url"; return 1; }
-  else
-    echo "unrecognised issue reference: $arg"; return 1
-  fi
-
-  local title
-  if [[ -n $owner ]]; then
-    title=$(gh issue view "$num" --repo "$owner/$repo" --json title -q .title)
-  else
-    title=$(builtin cd "$root" && gh issue view "$num" --json title -q .title)
-  fi
-  [[ -n $title ]] || { echo "could not resolve issue #$num"; return 1; }
-
-  local slug=$(_wt_issue_slug "$num" "$title")
-  print -r -- "→ $slug"
-  (builtin cd "$root" && _wt_core _wt_herdr "$slug") || return 1
-
-  # Prime the new pane. worktree open --focus leaves it current.
+# Prime the new pane. worktree open --focus leaves it current.
+_wt_herdr_prime() {
   local pane
-  pane=$(herdr pane current --current 2>/dev/null \
-         | python3 -c 'import sys,json;print(json.load(sys.stdin)["result"]["pane"]["pane_id"])' 2>/dev/null)
-  [[ -n $pane ]] || return 0
-  herdr pane send-text "$pane" "claude \"/ticket $num\"" >/dev/null 2>&1
+  pane=$(herdr pane current --current 2>/dev/null | jq -r '.result.pane.pane_id' 2>/dev/null)
+  [[ -n $pane && $pane != null ]] || return 0
+  herdr pane send-text "$pane" "claude \"/ticket $1\"" >/dev/null 2>&1
   herdr pane send-keys "$pane" enter >/dev/null 2>&1
+}
+
+# ── wtpr <PR-or-issue ref> / wti <issue ref> ────────────────────────
+wtpr() { _wt_pr    _wt_herdr _wt_herdr_prime "$@"; }
+wti()  { _wt_issue _wt_herdr _wt_herdr_prime "$@"; }
+
+# Popups inherit HERDR_ACTIVE_PANE_CWD, so they act on the pane you launched
+# from rather than wherever the popup shell happens to start.
+wtpr-pick() {
+  builtin cd "${HERDR_ACTIVE_PANE_CWD:-$PWD}" 2>/dev/null
+  _wt_pr_pick _wt_herdr _wt_herdr_prime
 }

--- a/zsh-plugins/wt-herdr/wt-herdr.plugin.zsh
+++ b/zsh-plugins/wt-herdr/wt-herdr.plugin.zsh
@@ -38,10 +38,3 @@ _wt_herdr_prime() {
 # ── wtpr <PR-or-issue ref> / wti <issue ref> ────────────────────────
 wtpr() { _wt_pr    _wt_herdr _wt_herdr_prime "$@"; }
 wti()  { _wt_issue _wt_herdr _wt_herdr_prime "$@"; }
-
-# Popups inherit HERDR_ACTIVE_PANE_CWD, so they act on the pane you launched
-# from rather than wherever the popup shell happens to start.
-wtpr-pick() {
-  builtin cd "${HERDR_ACTIVE_PANE_CWD:-$PWD}" 2>/dev/null
-  _wt_pr_pick _wt_herdr _wt_herdr_prime
-}

--- a/zsh-plugins/wt-zellij/README.md
+++ b/zsh-plugins/wt-zellij/README.md
@@ -20,8 +20,18 @@ local = "~/.dotfiles/zsh-plugins/wt-zellij"
 | Command | Does |
 | --- | --- |
 | `wtt [-b] <name> [base]` | upsert worktree, open in a zellij tab. No args: fzf picker |
+| `wttpr <n\|url\|owner/repo#n>` | PR **or** issue — a URL disambiguates, a bare number is probed |
+| `wtti <n\|url\|owner/repo#n>` | worktree for an issue, named `<n>-<slug>`, claude primed on `/ticket <n>` |
+| `wttpr-pick` | fzf over open PRs and issues, then as above |
 
 Tabs are named after the branch and reused if one already exists.
+
+## Picker
+
+`alt+w` opens `bin/wt-picker` in a floating pane: enter opens or creates,
+`^x` removes, `^r` pulls, and `^v`/`^y`/`^d`/`^l` are PR view / checks / diff /
+create. It only picks — creating and removing shell out to `wtt` and `wtrm`,
+since its own copy of the create path had already drifted from `wt-core`'s.
 
 ## Cleanup on exit
 

--- a/zsh-plugins/wt-zellij/README.md
+++ b/zsh-plugins/wt-zellij/README.md
@@ -22,7 +22,6 @@ local = "~/.dotfiles/zsh-plugins/wt-zellij"
 | `wtt [-b] <name> [base]` | upsert worktree, open in a zellij tab. No args: fzf picker |
 | `wttpr <n\|url\|owner/repo#n>` | PR **or** issue — a URL disambiguates, a bare number is probed |
 | `wtti <n\|url\|owner/repo#n>` | worktree for an issue, named `<n>-<slug>`, claude primed on `/ticket <n>` |
-| `wttpr-pick` | fzf over open PRs and issues, then as above |
 
 Tabs are named after the branch and reused if one already exists.
 

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -1,29 +1,31 @@
 #!/usr/bin/env bash
-# Worktree picker for Zellij keybinding
-# Pager commands (view/checks/diff) display in the floating pane via less
+# Worktree picker for the Zellij keybinding.
+# Pager commands (view/checks/diff) display in the floating pane via less.
 set -o pipefail
 
 export CLICOLOR_FORCE=1
 export GH_FORCE_TTY=1
 
-preview="${WT_CORE_BIN:?wt-core plugin not loaded}/wt-preview {1}"
+plugins=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+export WT_CORE_BIN="${WT_CORE_BIN:-$plugins/wt-core/bin}"
 
-root=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-root="${root%/.git}"
+# Creating and removing worktrees lives in wt-core. The picker only picks —
+# it had its own copy of the fetch/add fallback and the two drifted apart.
+# Sourced non-interactively, so no rc files and no startup cost.
+wt_call() {
+  zsh -c '
+    source "$1/wt-core/wt-core.plugin.zsh"
+    source "$1/wt-zellij/wt-zellij.plugin.zsh"
+    shift
+    "$@"
+  ' wt-picker "$plugins" "$@"
+}
 
-base_ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo "refs/remotes/origin/main")
-base="${base_ref##refs/remotes/origin/}"
-
-# Detect current branch to pre-select in fzf
 current=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 
-keys="ctrl-x,ctrl-r,ctrl-v,ctrl-y,ctrl-d,ctrl-l"
+input=$("$WT_CORE_BIN"/wt-list | awk -F'\t' '$1 != ""')
 
-# Build fzf input, track which line is current branch
-input=$(git worktree list --porcelain 2>/dev/null \
-  | awk '/^worktree /{ path=$2 } /^branch /{ branch=$2; sub("refs/heads/","",branch); printf "%s\t%s\n", branch, path }')
-
-# Find 1-based line number of current branch for --nth
+# 1-based line of the current branch, to pre-select it
 current_line=0
 if [[ -n $current ]]; then
   current_line=$(echo "$input" | awk -F'\t' -v b="$current" '{ if($1==b) { print NR; exit } }')
@@ -35,15 +37,12 @@ fzf_args=(
   --border
   --border-label=" enter: open · ^x: rm · ^r: pull · ^v: pr view · ^y: checks · ^d: diff · ^l: create pr "
   --border-label-pos=bottom
-  --preview "$preview" --preview-window='right:70%'
-  --print-query --expect="$keys"
+  --preview "$WT_CORE_BIN/wt-preview {1}" --preview-window='right:70%'
+  --print-query --expect="ctrl-x,ctrl-r,ctrl-v,ctrl-y,ctrl-d,ctrl-l"
 )
 
-# Pre-select current branch
 if [[ $current_line -gt 0 ]]; then
-  fzf_args+=(--scroll-off=0 --pointer='▶')
-  # Use --bind to jump to the right line on start
-  fzf_args+=(--bind "start:pos($current_line)")
+  fzf_args+=(--scroll-off=0 --pointer='▶' --bind "start:pos($current_line)")
 fi
 
 output=$(echo "$input" | fzf "${fzf_args[@]}") || true
@@ -60,14 +59,12 @@ fi
 
 [[ -n $name ]] || exit 0
 
-wt=$(git worktree list --porcelain 2>/dev/null \
-  | awk -v b="refs/heads/$name" '/^worktree /{ wt=$2 } /^branch /{ if($2==b) print wt }')
+wt=$("$WT_CORE_BIN"/wt-list "$name")
 
 case "$key" in
   ctrl-x)
     [[ -n $wt ]] || { echo "no worktree for $name" >&2; sleep 1; exit 1; }
-    git worktree remove "$wt" && git branch -d "$name" 2>/dev/null
-    echo "removed: $name"
+    wt_call wtrm "$name"
     sleep 1
     ;;
 
@@ -98,24 +95,7 @@ case "$key" in
     sleep 1
     ;;
 
-  *) # Enter — open/create
-    if [[ -z $wt ]]; then
-      wt_dir="$(dirname "$root")/worktrees/$(basename "$root")"
-      wt="$wt_dir/$name"
-      mkdir -p "$wt_dir"
-      git fetch origin "$base" --quiet || exit 1
-      git fetch origin "$name" --quiet 2>/dev/null
-      # existing local branch → existing remote branch → new from base
-      git worktree add "$wt" "$name" 2>/dev/null \
-        || git worktree add "$wt" -b "$name" "origin/$name" 2>/dev/null \
-        || git worktree add "$wt" -b "$name" "origin/$base" \
-        || exit 1
-    fi
-
-    if zellij action query-tab-names 2>/dev/null | grep -qxF "$name"; then
-      zellij action go-to-tab-name "$name"
-    else
-      zellij action new-tab --name "$name" --cwd "$wt" --close-on-exit -- "$(dirname "$0")/wt-shell" "$wt" "$name"
-    fi
+  *) # Enter — open existing or create from the typed name
+    wt_call wtt "$name"
     ;;
 esac

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -29,7 +29,16 @@ echo "  ${bold}Exiting worktree session${reset}"
 
 # Check for dirty state
 dirty_files=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-unpushed=$(git -C "$wt" log --oneline "@{upstream}..HEAD" 2>/dev/null | wc -l | tr -d ' ')
+
+# A branch created with -b and never pushed has no upstream, so @{upstream}..HEAD
+# errors and counts zero — reading as clean in the one case where commits are
+# about to be lost. Fall back to the remote default branch.
+if upstream=$(git -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null); then
+  unpushed=$(git -C "$wt" rev-list --count "${upstream}..HEAD" 2>/dev/null || echo 0)
+else
+  base=$(git -C "$wt" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo refs/remotes/origin/main)
+  unpushed=$(git -C "$wt" rev-list --count "${base##refs/remotes/}..HEAD" 2>/dev/null || echo 0)
+fi
 
 if [[ $dirty_files -eq 0 && $unpushed -eq 0 ]]; then
   # Clean — just remove silently

--- a/zsh-plugins/wt-zellij/wt-zellij.plugin.zsh
+++ b/zsh-plugins/wt-zellij/wt-zellij.plugin.zsh
@@ -17,7 +17,19 @@ _wt_tab() {
   fi
 }
 
+# write-chars targets the focused pane, which new-tab just made current. The
+# tab's shell is still starting, hence the wait.
+_wt_tab_prime() {
+  [[ -n $ZELLIJ ]] || return 0
+  sleep 0.5
+  zellij action write-chars "claude \"/ticket $1\""
+  zellij action write 13
+}
+
 # ── wtt — upsert worktree + zellij tab ──────────────────────────────
-wtt() { _wt_core _wt_tab "$@"; }
-compdef _wt_comp wtt
-zstyle ':fzf-tab:complete:wtt:*'  fzf-preview '~/.dotfiles/scripts/wt-preview $word'
+wtt()        { _wt_core    _wt_tab "$@"; }
+wttpr()      { _wt_pr      _wt_tab _wt_tab_prime "$@"; }
+wtti()       { _wt_issue   _wt_tab _wt_tab_prime "$@"; }
+wttpr-pick() { _wt_pr_pick _wt_tab _wt_tab_prime; }
+(( $+functions[compdef] )) && compdef _wt_comp wtt
+zstyle ':fzf-tab:complete:wtt:*'  fzf-preview "$WT_CORE_BIN/wt-preview $word"

--- a/zsh-plugins/wt-zellij/wt-zellij.plugin.zsh
+++ b/zsh-plugins/wt-zellij/wt-zellij.plugin.zsh
@@ -27,9 +27,8 @@ _wt_tab_prime() {
 }
 
 # ── wtt — upsert worktree + zellij tab ──────────────────────────────
-wtt()        { _wt_core    _wt_tab "$@"; }
-wttpr()      { _wt_pr      _wt_tab _wt_tab_prime "$@"; }
-wtti()       { _wt_issue   _wt_tab _wt_tab_prime "$@"; }
-wttpr-pick() { _wt_pr_pick _wt_tab _wt_tab_prime; }
+wtt()   { _wt_core  _wt_tab "$@"; }
+wttpr() { _wt_pr    _wt_tab _wt_tab_prime "$@"; }
+wtti()  { _wt_issue _wt_tab _wt_tab_prime "$@"; }
 (( $+functions[compdef] )) && compdef _wt_comp wtt
 zstyle ':fzf-tab:complete:wtt:*'  fzf-preview "$WT_CORE_BIN/wt-preview $word"


### PR DESCRIPTION
## What this does

`wtclean` asks GitHub for PR state instead of asking git. Everything here is squash-merged, so a merged branch shares no commit with what landed and `git branch --merged` calls it unmerged forever — which is why nothing was ever reclaimed and cleanup was a manual chore. Merged or closed PR + clean tree = worktree and branch go, plus orphaned branches whose worktree already vanished. No `gh`, no problem: a deleted upstream means the same thing.

Five verbs collapse to two. `wtd` was `wtrm` with a different argument, `wtp` aliased `git worktree prune`, and `wtpb` skipped every branch it existed to prune because `-d` refuses on anything squash-merged.

## Load-bearing decisions

- **One `gh pr list` up front**, not a query per branch — a dozen worktrees is a second, not a minute. It's meant to survive being put on a timer.
- **Uncommitted work always wins.** Dirty worktrees, the one you're standing in, and detached checkouts are never touched. `-n` dry-runs.
- **`wt-core` owns the GitHub primitives.** `wtpr`/`wti` were welded to herdr, so the zellij backend couldn't open a PR at all. Ref parsing, the PR-vs-issue probe, fork fetching and slugging moved to core; a backend is now two one-line bindings, and zellij gains `wttpr`/`wtti`. wt-herdr: 140 lines -> 41.
- **The popup wrappers stay in `config.d/zsh/conf.d/herdr.zsh`.** `wtpr-pick`/`wth-pick`/`wti-pick` already live there and own the `HERDR_ACTIVE_PANE_CWD` handling and hold-open-on-failure. Nothing here duplicates or moves them.
- **Not adopting `gwq`** (or any off-the-shelf manager): they use a single global worktree root, and the per-repo path derivation here is what keeps worktrees inside the org tree where the right mise env — and therefore the right Claude profile — applies.

## Bugs fixed along the way

- **`wt-shell` could eat commits.** It counted unpushed work with `@{upstream}..HEAD`; a branch created with `-b` and never pushed has no upstream, so git errored and the count came back zero — reading as clean in the exact case where commits were about to be lost. `wtt -b foo`, commit, close the tab, gone.
- **Two dangling paths from the plugin split (#76)** — `scripts/wt-picker` (the zellij `alt+w` binding) and `scripts/wt-preview` (the `wtt` completion preview, single-quoted so `$word` never expanded either). Both files were deleted by the split; nothing repointed at the new locations.
- `_wt_repo_root` aborted on an unmatched glob instead of reporting no local checkout; `wtrm`'s zellij tab close fired on whichever tab was current rather than the worktree's.
- Porcelain parsing went from four drifting copies to one `bin/wt-list`, and `wt-picker` no longer carries its own stale copy of the create path.

## How to confirm

```sh
wtclean -n          # dry run; should report "dropped 0"
alt+w               # zellij worktree picker — the binding that was dead
```

`config.d/zsh/conf.d/herdr.zsh` is untouched, so the herdr popups behave exactly as before.

## Not covered by testing

Syntax, the porcelain parsing, ref parsing and the herdr pane-id lookup are verified. The interactive paths — picker enter/`^x`, claude priming, herdr open — need a TTY and haven't been exercised.

## History

The second commit reverts a mistake in the first: it had duplicated `wtpr-pick` into the plugin and repointed `alt+w` from `wth-pick` to bare `wth`, on the incorrect premise that those functions didn't exist. They do, in `conf.d/herdr.zsh` since f466449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK2s5sJBVLc5Edhm3cZ3H