### PR TITLE
refactor(wt): zsh throughout, wtclean as a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**wt-\* helpers are zsh; `wtclean` is a script:**
+
+- These are zsh plugins, so the `bin/` helpers had no business being bash — zsh is guaranteed present here and macOS still ships bash 3.2. Not purely cosmetic: bash's single-char read in `wt-shell`'s keep/remove prompt is `read -rsn1`, which zsh spells `read -rsk1`, and `${BASH_SOURCE[0]}` becomes `${0:A}`
+- `wtclean` moved out of the plugin into `bin/wtclean`; the plugin keeps a one-line shim onto it. A function is only worth defining when it has to mutate the shell — `wt` and `wtrm` cd, a GC pass doesn't. The distinction has teeth: a shell started before an update ran a stale `wtclean` against a `wt-list` that didn't exist on disk yet, silently processed zero worktrees while reporting `removed 0, kept 0`, and still went on to delete seven branches. A script is re-read every invocation, so it cannot half-run
+
+
 **`setup-linux` — headless Ubuntu/Debian boxes:**
 
 - Everything load-bearing already lived in mise, so the port was mostly gating rather than porting. brew's real job here is casks — ghostty, fonts, 1Password, raycast — none of which a headless box wants

--- a/config.d/zellij/config.kdl
+++ b/config.d/zellij/config.kdl
@@ -175,7 +175,7 @@ keybinds clear-defaults=true {
         bind "Alt Shift p" { ToggleGroupMarking; }
         bind "Ctrl q" { Quit; }
         bind "Alt w" {
-            Run "bash" "-c" "$HOME/.dotfiles/zsh-plugins/wt-zellij/bin/wt-picker" {
+            Run "zsh" "-c" "$HOME/.dotfiles/zsh-plugins/wt-zellij/bin/wt-picker" {
                 floating true
                 hold_on_close false
                 x "5%"

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -67,10 +67,20 @@ backend is only ever the two functions above.
 
 ## Bin
 
+Everything here is zsh — these are zsh plugins, zsh is guaranteed present, and
+macOS still ships bash 3.2.
+
 `wt-list` prints `branch<TAB>path` per worktree, or the path of a named branch.
 Parsing `worktree list --porcelain` lived in four places and drifted; this is
 the one copy. `wt-preview` renders the fzf preview: PR details if there's a PR,
 otherwise log plus tree.
+
+`wtclean` is a script rather than a function, and `wtclean()` in the plugin is
+a one-line shim onto it. A function is only worth defining when it has to
+mutate the shell — `wt` and `wtrm` cd, so they qualify; a GC pass doesn't. The
+difference matters: a shell started before an update will happily run a stale
+function against changed helpers and half-succeed, which is exactly how a run
+once reported `removed 0, kept 0` while still deleting seven branches.
 
 ## Exports
 

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Emits "branch<TAB>path", one worktree per line. With an argument, prints only
 # the path of that branch. Parsing `worktree list --porcelain` lived in four
 # places and drifted; this is the one copy.

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Preview for wt fzf picker
 # Shows PR details if one exists, otherwise git log + file tree
 # Args: $1 = "branch\tpath" or just "branch" (fzf-tab sends $word)
 set -euo pipefail
 
 branch="${1%%$'\t'*}"
-path=$("$(dirname "${BASH_SOURCE[0]}")/wt-list" "$branch")
+path=$("${0:A:h}/wt-list" "$branch")
 [[ -n $path ]] || exit 0
 
 # Try PR view first — shows title, status, checks, reviewers

--- a/zsh-plugins/wt-core/bin/wtclean
+++ b/zsh-plugins/wt-core/bin/wtclean
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+# Garbage-collect worktrees and branches against GitHub PR state.
+# The logic lives in the plugin next door so wtrm can share _wt_pr_state;
+# this runner exists so the code executed is always the code on disk.
+set -o pipefail
+
+source "${0:A:h:h}/wt-core.plugin.zsh" || {
+  print -u2 "wtclean: cannot load wt-core.plugin.zsh"
+  exit 1
+}
+_wt_clean "$@"

--- a/zsh-plugins/wt-core/wt-core.plugin.zsh
+++ b/zsh-plugins/wt-core/wt-core.plugin.zsh
@@ -274,6 +274,9 @@ wtrm() {
 }
 
 # ── wtclean [-n] ────────────────────────────────────────────────────
+# Runs as bin/wtclean, not as this function: it mutates no shell state, so
+# there is no reason for a shell that was started three commits ago to be the
+# thing executing it. The shim below re-reads the script every invocation.
 # Everything is squash-merged, so a merged branch still looks unmerged to
 # `git branch --merged` and nothing ever gets reclaimed. GitHub's PR state is
 # the only reliable signal; without gh, a deleted upstream stands in for it.
@@ -305,7 +308,7 @@ _wt_pr_state() {
     && echo MERGED || echo NONE
 }
 
-wtclean() {
+_wt_clean() {
   local root=$(_wt_root)
   [[ -z $root ]] && { echo "not in a git repo"; return 1; }
   local dry=0
@@ -380,6 +383,8 @@ wtclean() {
   _wt_prs=()   # scoped to the run — a stale map misclassifies later calls
   echo "wtclean: removed $removed, kept $kept, dropped $dropped branch(es)"
 }
+
+wtclean() { "$WT_CORE_BIN"/wtclean "$@"; }
 
 # ── Completions ─────────────────────────────────────────────────────
 _wt_branches() {

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Worktree picker for the Zellij keybinding.
 # Pager commands (view/checks/diff) display in the floating pane via less.
 set -o pipefail
@@ -6,7 +6,7 @@ set -o pipefail
 export CLICOLOR_FORCE=1
 export GH_FORCE_TTY=1
 
-plugins=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+plugins=${0:A:h:h:h}
 export WT_CORE_BIN="${WT_CORE_BIN:-$plugins/wt-core/bin}"
 
 # Creating and removing worktrees lives in wt-core. The picker only picks —
@@ -29,6 +29,7 @@ input=$("$WT_CORE_BIN"/wt-list | awk -F'\t' '$1 != ""')
 current_line=0
 if [[ -n $current ]]; then
   current_line=$(echo "$input" | awk -F'\t' -v b="$current" '{ if($1==b) { print NR; exit } }')
+  current_line=${current_line:-0}
 fi
 
 fzf_args=(
@@ -41,7 +42,7 @@ fzf_args=(
   --print-query --expect="ctrl-x,ctrl-r,ctrl-v,ctrl-y,ctrl-d,ctrl-l"
 )
 
-if [[ $current_line -gt 0 ]]; then
+if (( current_line > 0 )); then
   fzf_args+=(--scroll-off=0 --pointer='▶' --bind "start:pos($current_line)")
 fi
 

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Wrapper shell for worktree tabs — auto-cleans or prompts on exit
 # Args: $1 = worktree path, $2 = branch name
 set -euo pipefail
@@ -22,7 +22,9 @@ zsh -i || true
 # Guard: never touch the main worktree
 root=$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
 root="${root%/.git}"
-[[ "$wt" == "$root" ]] && exit 0
+if [[ "$wt" == "$root" ]]; then
+  exit 0
+fi
 
 echo ""
 echo "  ${bold}Exiting worktree session${reset}"
@@ -40,7 +42,7 @@ else
   unpushed=$(git -C "$wt" rev-list --count "${base##refs/remotes/}..HEAD" 2>/dev/null || echo 0)
 fi
 
-if [[ $dirty_files -eq 0 && $unpushed -eq 0 ]]; then
+if (( dirty_files == 0 && unpushed == 0 )); then
   # Clean — just remove silently
   if git worktree remove "$wt" 2>/dev/null; then
     git -C "$root" branch -d "$name" 2>/dev/null
@@ -51,10 +53,10 @@ if [[ $dirty_files -eq 0 && $unpushed -eq 0 ]]; then
 fi
 
 # Dirty — show warnings and prompt
-if [[ $dirty_files -gt 0 ]]; then
+if (( dirty_files > 0 )); then
   echo "  ${yellow}You have ${dirty_files} uncommitted file(s). These will be lost if you remove the worktree.${reset}"
 fi
-if [[ $unpushed -gt 0 ]]; then
+if (( unpushed > 0 )); then
   echo "  ${yellow}You have ${unpushed} unpushed commit(s). These will be lost if you remove the worktree.${reset}"
 fi
 
@@ -65,7 +67,8 @@ echo ""
 printf "  ${dim}press 1 or 2${reset} "
 
 while true; do
-  read -rsn1 answer
+  # zsh spells bash's `read -n1` as -k1; -s keeps it off the screen
+  read -rsk1 answer
   case "$answer" in
     1)
       echo ""


### PR DESCRIPTION
## What this does

Two changes, both from the same root cause — a `wtclean` run that reported success while doing half its job.

**Every `bin/` helper is zsh now.** These are zsh plugins; bash was inertia. zsh is guaranteed present (it's the shell they load into) and macOS still ships bash 3.2. Two of the ports would have broken silently rather than loudly:

- `wt-shell`'s keep/remove prompt used `read -rsn1`. zsh spells the char count `-k`, so an unported `-n1` waits for a newline that never comes — the prompt just hangs.
- `${BASH_SOURCE[0]}` -> `${0:A}` in `wt-preview` and `wt-picker`.

**`wtclean` is a script, not a function.** `bin/wtclean` sources the plugin and calls `_wt_clean`; the plugin keeps `wtclean() { "$WT_CORE_BIN"/wtclean "$@"; }`.

## Why

A function is only worth defining when it has to mutate the shell. `wt`/`wtt`/`wth` cd, `wtrm` cds and closes a tab — those qualify. A GC pass doesn't, and being a function is what let a shell started several commits earlier run a stale `wtclean` against a `wt-list` that wasn't on disk yet. It processed **zero** worktrees, reported `removed 0, kept 0` as though the repo were clean, and then went on to delete seven branches from the half that still worked.

Nothing was lost — all seven were merged, and git refuses `branch -D` on a branch checked out in a worktree, which is the only reason the empty worktree list didn't cause damage. That's luck, not design. A script is re-read at every invocation, so it can't diverge from its helpers, and if the source is missing it fails before doing anything.

Same reasoning applies to anything added later that doesn't cd.

## How to confirm

```sh
wtclean -n                              # via the shim
zsh-plugins/wt-core/bin/wtclean -n      # direct; identical output
```

Both verified, along with `wt-list`, `wt-preview`, the picker's path derivation, and `zsh -n` across every script.

The zellij `alt+w` binding moves from `Run "bash" "-c"` to `Run "zsh" "-c"` for consistency — it was already fine, since the shebang governs.

## Not covered by testing

The interactive paths still need a TTY: `wt-shell`'s prompt (where the `read` change lands), picker enter/`^x`, herdr open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK2s5sJBVLc5Edhm3cZ3H