### PR TITLE
feat(wt): --help and --completions on every bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**`--help` and `--completions` on the wt bins:**
+
+- Brings them in line with the Rust binaries, which have always answered both. `task generate:completions` enumerates them by path rather than `command -v`, since plugin internals aren't on `PATH` and the existing gate would have skipped them silently
+- The scripts taking a branch emit a completion that shells back to themselves by absolute path, so adding completion didn't reintroduce a copy of the `worktree list --porcelain` parsing that was just deduplicated into `wt-list`
+- `wt-picker` and `wt-shell` are never run by hand, but `--help` still beats reading the source to work out what a file in `bin/` is for
+
+
 **wt-\* helpers are zsh; `wtclean` is a script:**
 
 - These are zsh plugins, so the `bin/` helpers had no business being bash — zsh is guaranteed present here and macOS still ships bash 3.2. Not purely cosmetic: bash's single-char read in `wt-shell`'s keep/remove prompt is `read -rsn1`, which zsh spells `read -rsk1`, and `${BASH_SOURCE[0]}` becomes `${0:A}`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -630,6 +630,7 @@ tasks:
           TOOL: "{{.ITEM}}"
           CMD: "{{.ITEM}} completion zsh"
       # Custom completion commands
+      - task: generate:completions:wt
       - task: generate:completions:gen
         vars: { TOOL: aube, CMD: "aube completion zsh" }
       - task: generate:completions:gen
@@ -717,6 +718,34 @@ tasks:
         else
           rm -f "$new"
         fi
+
+  generate:completions:wt:
+    internal: true
+    run: always
+    deps: [generate:completions:setup]
+    vars:
+      COMP_DIR: "{{.HOME}}/.config/zsh/completions"
+      STATE: "/tmp/.task-completions-changed"
+    cmds:
+      # Not on PATH — they are plugin internals — so `command -v` cannot find
+      # them and they are enumerated by path.
+      - |
+        for bin in {{.HOME}}/.dotfiles/zsh-plugins/*/bin/*; do
+          [ -x "$bin" ] || continue
+          name=$(basename "$bin")
+          new=$(mktemp)
+          if "$bin" --completions zsh > "$new" 2>/dev/null && [ -s "$new" ]; then
+            if ! cmp -s "$new" "{{.COMP_DIR}}/_$name" 2>/dev/null; then
+              mv "$new" "{{.COMP_DIR}}/_$name"
+              printf "{{.OK}} %s\n" "$name"
+              echo "$name" >> {{.STATE}}
+            else
+              rm -f "$new"
+            fi
+          else
+            rm -f "$new"
+          fi
+        done
 
   generate:completions:lsd:
     internal: true

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -70,6 +70,12 @@ backend is only ever the two functions above.
 Everything here is zsh — these are zsh plugins, zsh is guaranteed present, and
 macOS still ships bash 3.2.
 
+Each script answers `--help` and `--completions zsh`, matching the convention
+the Rust binaries follow. `task generate:completions` picks them up by path
+rather than `command -v`, since plugin internals aren't on `PATH`. The ones
+taking a branch emit a completion that calls the script back by absolute path,
+so the porcelain parsing stays in one place.
+
 `wt-list` prints `branch<TAB>path` per worktree, or the path of a named branch.
 Parsing `worktree list --porcelain` lived in four places and drifted; this is
 the one copy. `wt-preview` renders the fzf preview: PR details if there's a PR,

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -5,6 +5,23 @@
 # Branch is empty for detached worktrees — callers that display it filter those.
 set -o pipefail
 
+case ${1:-} in
+  -h|--help)
+    print -r -- 'usage: wt-list [branch]
+
+Prints "branch<TAB>path" for every worktree. Given a branch, prints only
+that worktree'\''s path. Branch is empty for detached worktrees.'
+    exit 0 ;;
+  --completions)
+    # Calls back into itself by absolute path so the porcelain parsing above
+    # stays the only copy.
+    print -r -- "#compdef wt-list
+local -a branches
+branches=(\${(f)\"\$(${0:A} | cut -f1)\"})
+_describe 'worktree branch' branches"
+    exit 0 ;;
+esac
+
 git worktree list --porcelain 2>/dev/null | awk -v want="${1:-}" '
   function emit() {
     if (want == "") printf "%s\t%s\n", b, p

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -4,6 +4,22 @@
 # Args: $1 = "branch\tpath" or just "branch" (fzf-tab sends $word)
 set -euo pipefail
 
+case ${1:-} in
+  -h|--help)
+    print -r -- 'usage: wt-preview <branch>
+
+fzf preview for the worktree pickers: PR details when a PR exists,
+otherwise git log plus a one-level file tree. Accepts "branch<TAB>path"
+as well as a bare branch, since fzf-tab passes the whole line.'
+    exit 0 ;;
+  --completions)
+    print -r -- "#compdef wt-preview
+local -a branches
+branches=(\${(f)\"\$(${0:A:h}/wt-list | cut -f1)\"})
+_describe 'worktree branch' branches"
+    exit 0 ;;
+esac
+
 branch="${1%%$'\t'*}"
 path=$("${0:A:h}/wt-list" "$branch")
 [[ -n $path ]] || exit 0

--- a/zsh-plugins/wt-core/bin/wtclean
+++ b/zsh-plugins/wt-core/bin/wtclean
@@ -4,6 +4,24 @@
 # this runner exists so the code executed is always the code on disk.
 set -o pipefail
 
+case ${1:-} in
+  -h|--help)
+    print -r -- 'usage: wtclean [-n|--dry-run]
+
+Removes worktrees whose PR is merged or closed, and branches whose
+worktree is already gone, asking gh for PR state — squash merges make
+`git branch --merged` useless. Keeps anything dirty, the worktree you
+are standing in, and detached checkouts. Agent worktrees under
+.claude/worktrees always go.'
+    exit 0 ;;
+  --completions)
+    print -r -- "#compdef wtclean
+_arguments \\
+  '(-n --dry-run)'{-n,--dry-run}'[report what would go, change nothing]' \\
+  '(-h --help)'{-h,--help}'[show usage]'"
+    exit 0 ;;
+esac
+
 source "${0:A:h:h}/wt-core.plugin.zsh" || {
   print -u2 "wtclean: cannot load wt-core.plugin.zsh"
   exit 1

--- a/zsh-plugins/wt-zellij/README.md
+++ b/zsh-plugins/wt-zellij/README.md
@@ -43,6 +43,12 @@ This only covers worktrees opened *through* `wtt`. Anything created another way
 — agent worktrees especially — is never wrapped, so `wtclean` from `wt-core` is
 still worth running.
 
+## Bin
+
+`wt-picker` and `wt-shell` are zsh, and answer `--help` and `--completions zsh`
+like the rest. Neither is meant to be run by hand — `alt+w` and `wtt` invoke
+them — but `--help` beats reading the source to find out what they are.
+
 ## Exports
 
 `WT_ZELLIJ_BIN` — this plugin's `bin/`.

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -3,6 +3,21 @@
 # Pager commands (view/checks/diff) display in the floating pane via less.
 set -o pipefail
 
+case ${1:-} in
+  -h|--help)
+    print -r -- 'usage: wt-picker
+
+fzf over worktrees, for the zellij alt+w binding. Takes no arguments.
+  enter  open or create      ^x  remove       ^r  pull --rebase
+  ^v     pr view             ^y  pr checks    ^d  pr diff
+  ^l     create pr'
+    exit 0 ;;
+  --completions)
+    print -r -- "#compdef wt-picker
+_arguments '(-h --help)'{-h,--help}'[show usage]'"
+    exit 0 ;;
+esac
+
 export CLICOLOR_FORCE=1
 export GH_FORCE_TTY=1
 

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -3,6 +3,21 @@
 # Args: $1 = worktree path, $2 = branch name
 set -euo pipefail
 
+case ${1:-} in
+  -h|--help)
+    print -r -- 'usage: wt-shell <worktree-path> <branch>
+
+Wrapper shell for worktree tabs. Runs an interactive zsh, then on exit
+removes the worktree if it is clean, or prompts when there are
+uncommitted changes or unpushed commits. Never touches a main checkout.
+Invoked by wtt, not by hand.'
+    exit 0 ;;
+  --completions)
+    print -r -- "#compdef wt-shell
+_arguments '1:worktree path:_files -/' '2:branch:'"
+    exit 0 ;;
+esac
+
 wt="$1"
 name="$2"
 


### PR DESCRIPTION
## What this does

All five `bin/` scripts now answer `--help` and `--completions zsh`, matching what the Rust binaries have always done — the README's "all binaries support `--help` and have shell completions" was quietly untrue of these.

`task generate:completions` picks them up via a new `generate:completions:wt`, modelled on the existing `lsd` special case.

## Load-bearing decisions

- **Enumerated by path, not `command -v`.** These are plugin internals and aren't on `PATH`, so the standard `generate:completions:gen` gate (`status: ["! command -v {{.TOOL}}"]`) would have evaluated true and skipped every one of them without a word. The task globs `zsh-plugins/*/bin/*` instead, so anything added later is picked up for free.
- **The completions call back to the script by absolute path.** `wt-list` and `wt-preview` complete a branch argument, which needs the worktree list — and embedding that awk in a completion file would have been a fourth copy of the parsing #77 just consolidated. The emitted file shells out to `wt-list` at its generation-time absolute path instead.
- **`--help` exits before `wtclean` sources the plugin**, so it stays instant and works even if the plugin is broken.
- `wt-picker` and `wt-shell` take no arguments worth completing — they're driven by `alt+w` and `wtt`. They still get `--help`, because finding an unexplained executable in `bin/` and having to read it is the thing worth fixing.

## How to confirm

```sh
zsh-plugins/wt-core/bin/wtclean --help
zsh-plugins/wt-core/bin/wt-list --completions zsh
task generate:completions
```

Verified: all five emit both; every emitted completion parses under `zsh -n`; `compinit` loads all five from a scratch `fpath` without complaint; and `wt-list`, `wt-preview` and `wtclean` still do their actual jobs unchanged, through the script and through the shim.

## Not covered by testing

Whether the completions are *useful* at the prompt — they parse and load, but tab-completing them needs an interactive shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK2s5sJBVLc5Edhm3cZ3H