### PR TITLE
perf(wt): fan out wtclean's per-worktree work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**`wtclean` fans out the per-worktree work:**
+
+- The two costs that scale with worktree count are `git status` and the removal itself. Both are per-worktree independent, so they go through GNU parallel, or `xargs -P` where it isn't installed. Concurrent `git worktree remove` turns out to be safe — each touches only its own directory under `.git/worktrees`, verified 12-way with a clean `fsck` after
+- Branch deletion went the opposite way: **batched**, not parallelised. `git branch -D` takes many refs in one invocation, which is a single `packed-refs` rewrite instead of a pile of processes contending for its lock
+- Both fan-out backends pass the path as a real argument rather than substituting it into a command string, so a worktree path with a space in it survives. GNU parallel needs `-q` for that, without which it re-tokenises the snippet and `sh -c` gets only the first word
+- Classification now happens before any of it, so the expensive probe only runs on worktrees that are still candidates — the one you're standing in, detached checkouts and agent worktrees never get walked at all
+
+
 **wt-\* helpers are zsh; `wtclean` is a script:**
 
 - These are zsh plugins, so the `bin/` helpers had no business being bash — zsh is guaranteed present here and macOS still ships bash 3.2. Not purely cosmetic: bash's single-char read in `wt-shell`'s keep/remove prompt is `read -rsn1`, which zsh spells `read -rsk1`, and `${BASH_SOURCE[0]}` becomes `${0:A}`

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -42,6 +42,15 @@ detritus and always go.
 One `gh pr list` up front rather than a query per branch, which is the
 difference between a second and a minute. Safe to run from cron.
 
+The two per-worktree costs are fanned out with GNU parallel, falling back to
+`xargs -P`: `git status` (which walks the whole working tree — the expensive
+part on a monorepo) and the removal itself (mostly `rm -rf`). Concurrent
+`git worktree remove` is safe because each touches only its own admin
+directory. Branch deletion goes the other way and is *batched* into a single
+`git branch -D` — many refs is one `packed-refs` rewrite, where racing
+deletions would contend for its lock. On a handful of small worktrees none of
+this is measurable; it's for the checkouts with `node_modules` in them.
+
 ## Extending
 
 A backend is one function taking `(name, path)`, passed to `_wt_core`:

--- a/zsh-plugins/wt-core/wt-core.plugin.zsh
+++ b/zsh-plugins/wt-core/wt-core.plugin.zsh
@@ -308,6 +308,19 @@ _wt_pr_state() {
     && echo MERGED || echo NONE
 }
 
+# Fan a snippet (which reads its item as "$1") over stdin lines. GNU parallel
+# when it's installed, xargs -P otherwise. Both pass the item as a real
+# argument rather than substituting it textually, so paths survive intact.
+# -k/-I keep output in input order.
+_wt_fan() {
+  local snippet=$1
+  if command -v parallel >/dev/null; then
+    parallel --will-cite -k -q sh -c "$snippet" _ {}
+  else
+    xargs -P 8 -I {} sh -c "$snippet" _ {}
+  fi
+}
+
 _wt_clean() {
   local root=$(_wt_root)
   [[ -z $root ]] && { echo "not in a git repo"; return 1; }
@@ -320,9 +333,11 @@ _wt_clean() {
   git -C "$root" fetch --prune --quiet 2>/dev/null
   _wt_pr_cache "$repo"
 
+  # Classify on cheap facts only — nothing here touches the working tree.
   # Split by hand: tab is IFS-whitespace, so `read` would collapse the empty
   # branch field of a detached worktree and shift the path into it.
-  local line wt branch label state removed=0 kept=0
+  local line wt branch label removed=0 kept=0
+  local -a agents candidates cand_branch
   while IFS= read -r line; do
     branch=${line%%$'\t'*}
     wt=${line#*$'\t'}
@@ -330,38 +345,70 @@ _wt_clean() {
     label=${branch:-$wt}
     git worktree unlock "$wt" 2>/dev/null
 
-    # Agent worktrees are session detritus — always force.
-    if [[ $wt == */.claude/worktrees/* ]]; then
-      (( dry )) && { echo "  would nuke (agent): $wt"; continue }
-      git worktree remove --force "$wt" 2>/dev/null \
-        && { echo "  removed (agent): $wt"; ((removed++)) }
-      continue
-    fi
-
+    # Agent worktrees are session detritus — always force, never probed.
+    [[ $wt == */.claude/worktrees/* ]] && { agents+=("$wt"); continue }
     [[ $wt == "$here" ]] && { echo "  kept:    $label (you're in it)"; ((kept++)); continue }
-    if [[ -n $(git -C "$wt" status --porcelain 2>/dev/null) ]]; then
-      echo "  kept:    $label (uncommitted changes)"; ((kept++)); continue
-    fi
     [[ -z $branch ]] && { echo "  kept:    $label (detached)"; ((kept++)); continue }
+    candidates+=("$wt"); cand_branch+=("$branch")
+  done < <("$WT_CORE_BIN"/wt-list)
 
+  # `git status` walks the whole working tree, which on a monorepo is the
+  # expensive part of the run. Each worktree is independent, so fan them out.
+  local -A dirty
+  local d
+  if (( ${#candidates} )); then
+    while IFS=$'\t' read -r wt d; do
+      dirty[$wt]=$d
+    done < <(printf '%s\n' $candidates \
+      | _wt_fan 'printf "%s\t%s\n" "$1" "$(git -C "$1" status --porcelain 2>/dev/null | wc -l | tr -d " ")"')
+  fi
+
+  local -a doomed doomed_branch
+  local i state
+  for (( i = 1; i <= ${#candidates}; i++ )); do
+    wt=$candidates[i]; branch=$cand_branch[i]
+    if (( ${dirty[$wt]:-0} > 0 )); then
+      echo "  kept:    $branch (uncommitted changes)"; ((kept++)); continue
+    fi
     state=$(_wt_pr_state "$branch" "$repo")
     case $state in
       MERGED|CLOSED)
-        (( dry )) && { echo "  would remove: $branch (PR $state)"; continue }
-        if git worktree remove "$wt" 2>/dev/null; then
-          git -C "$root" branch -D "$branch" >/dev/null 2>&1
-          echo "  removed: $branch (PR $state)"; ((removed++))
+        if (( dry )); then
+          echo "  would remove: $branch (PR $state)"
         else
-          echo "  kept:    $branch (in use)"; ((kept++))
+          doomed+=("$wt"); doomed_branch+=("$branch")
         fi ;;
       OPEN) echo "  kept:    $branch (PR open)"; ((kept++)) ;;
       *)    echo "  kept:    $branch (no PR)"; ((kept++)) ;;
     esac
-  done < <("$WT_CORE_BIN"/wt-list)
+  done
 
-  # Branches whose worktree is already gone.
+  # Removal is almost entirely rm -rf, and concurrent `git worktree remove`
+  # touches only its own admin directory — no shared lock to contend on.
+  if (( dry )); then
+    (( ${#agents} )) && printf '  would nuke (agent): %s\n' $agents
+  else
+    (( ${#agents} )) && printf '%s\n' $agents | _wt_fan 'git worktree remove --force "$1" 2>/dev/null'
+    (( ${#doomed} )) && printf '%s\n' $doomed | _wt_fan 'git worktree remove "$1" 2>/dev/null'
+
+    # Report on what actually went: removal still refuses on a locked or
+    # in-use worktree, and a fanned-out exit status won't tell us which.
+    for wt in $agents; do
+      [[ -d $wt ]] || { echo "  removed (agent): $wt"; ((removed++)) }
+    done
+    for (( i = 1; i <= ${#doomed}; i++ )); do
+      if [[ -d $doomed[i] ]]; then
+        echo "  kept:    $doomed_branch[i] (in use)"; ((kept++))
+      else
+        echo "  removed: $doomed_branch[i]"; ((removed++))
+      fi
+    done
+  fi
+
+  # Branches whose worktree is gone — including the ones just removed, since
+  # this reads the registry fresh.
   local base=$(_wt_base) b dropped=0
-  local -a live
+  local -a live drop
   live=(${(f)"$(_wt_named | cut -f1)"})
   for b in ${(f)"$(git -C "$root" for-each-ref --format='%(refname:short)' refs/heads/)"}; do
     [[ $b == "$base" ]] && continue
@@ -369,14 +416,21 @@ _wt_clean() {
     state=$(_wt_pr_state "$b" "$repo")
     if [[ $state == MERGED || $state == CLOSED ]]; then
       (( dry )) && { echo "  would drop branch: $b (PR $state)"; continue }
-      git -C "$root" branch -D "$b" >/dev/null 2>&1 \
-        && { echo "  dropped branch: $b (PR $state)"; ((dropped++)) }
+      drop+=("$b")
     elif git -C "$root" merge-base --is-ancestor "$b" "origin/$base" 2>/dev/null; then
       (( dry )) && { echo "  would drop branch: $b (merged)"; continue }
-      git -C "$root" branch -D "$b" >/dev/null 2>&1 \
-        && { echo "  dropped branch: $b (merged)"; ((dropped++)) }
+      drop+=("$b")
     fi
   done
+  # One invocation, not one per branch: many refs is a single packed-refs
+  # rewrite, and racing deletions would contend for its lock.
+  if (( ${#drop} )); then
+    git -C "$root" branch -D $drop >/dev/null 2>&1
+    for b in $drop; do
+      git -C "$root" show-ref --verify --quiet "refs/heads/$b" \
+        || { echo "  dropped branch: $b"; ((dropped++)) }
+    done
+  fi
 
   local -a pruneargs=(-v); (( dry )) && pruneargs+=(-n)
   git worktree prune $pruneargs


### PR DESCRIPTION
## What this does

Three different treatments, because the phases aren't alike:

| phase | before | after |
|---|---|---|
| `git status` per worktree | serial | fanned out |
| `git worktree remove` | serial | fanned out |
| `git branch -D` | one call per branch | **batched** into one call |
| gh PR lookup | already one call | unchanged |

GNU parallel when it's installed, `xargs -P 8` when it isn't.

## Load-bearing decisions

- **Concurrent `git worktree remove` is safe, and I checked rather than assumed.** Each removal touches only its own directory under `.git/worktrees`, so there's no shared lock. Ran 12-way against a scratch repo: no failures, admin directory consistent, `git worktree prune` found nothing left over, `fsck` clean.
- **Branch deletion is batched, not parallelised** — the opposite call. `git branch -D` accepts many refs, so one invocation is a single `packed-refs` rewrite; N racing deletions would contend for one lock to do the same work.
- **Both backends pass the item as a real argument** (`sh -c 'snippet' _ {}`) rather than substituting into a command string, so a worktree path containing a space survives. GNU parallel needs `-q` for this — without it, it re-tokenises the snippet and `sh -c` receives only the first word, which fails in a genuinely confusing way.
- **Classification runs before the probe.** The worktree you're standing in, detached checkouts and `.claude/worktrees` agent worktrees are decided on cheap facts and never walked at all.
- **Reporting is by observed outcome**, not exit status — a fanned-out removal can't tell you *which* one refused, so each path is re-checked afterwards and a survivor is reported as `kept: … (in use)`.

## How to confirm

Functional test on a scratch repo, 6 worktrees, two deliberately dirty (one untracked file, one modified tracked file), `_wt_pr_state` stubbed to MERGED so removal actually fires:

```
kept:    b2 (uncommitted changes)
kept:    b5 (uncommitted changes)
removed: b1 / b3 / b4 / b6
dropped branch: b1 / b3 / b4 / b6
wtclean: removed 4, kept 2, dropped 4 branch(es)
```

Both dirty worktrees survived with content intact, registry consistent, `fsck` clean. Repeated with `PATH=/usr/bin:/bin` to force the `xargs` fallback — same result. Dry run beforehand changed nothing on disk.

## Honest note on the payoff

**Unmeasurable on this repo.** Eight small worktrees, and the fanned-out probe and the serial one are both under noise. This is for the checkouts with `node_modules` in them, where `git status` walks a few hundred thousand paths and removal is a large `rm -rf`. If you only ever run it here, it buys nothing.

Branches off `main`, and touches only `_wt_clean` in the plugin — no overlap with #80, which is in `bin/wtclean` and the Taskfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK2s5sJBVLc5Edhm3cZ3H