### PR TITLE
refactor: check-completions belongs to zarg, not scripts/lib

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -45,7 +45,7 @@ jobs:
       # Every script is exercised through zarg here, so a spec that parses but
       # renders a broken completion fails the build rather than the shell.
       - name: Completions
-        run: zsh scripts/lib/check-completions
+        run: zsh zsh-plugins/zarg/check-completions.zsh
 
   zarg:
     name: zarg behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 - Handles `--long value`, `--long=value`, `-s value`, attached shorts (`-b192`), clustered flags (`-nk`), `--`, defaults, `env=` fallbacks, `required`, `variadic`, and `values=` sets validated before the script body runs. Unknown flags get a did-you-mean
 - Fidelity across shells is uneven and that is the shells' doing: `complete=` names a zsh completion function, so fish and bash fall back to file completion there. Declared value sets work in all three
 - The emitters live in a separate `completions.zsh` sourced only on demand — scripts load zarg on every invocation and generate completions about once per converge
-- 32 tests in `zsh-plugins/zarg/test.zsh`, plus `scripts/lib/check-completions`, which asserts every script's emitted completion actually parses in zsh, bash and fish. Both run in CI and on pre-push; the old `rust-tests.yml` is now `scripts.yml`
+- 32 tests in `zsh-plugins/zarg/test.zsh`, plus `zsh-plugins/zarg/check-completions.zsh`, which asserts every script's emitted completion actually parses in zsh, bash and fish. Both run in CI and on pre-push; the old `rust-tests.yml` is now `scripts.yml`
 
 **`wtclean` uses zarg too:**
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,4 +42,4 @@ pre-push:
     # prevent, so prove all three shells still accept what it emits.
     completions:
       glob: "{scripts/**,zsh-plugins/zarg/**}"
-      run: scripts/lib/check-completions
+      run: zsh-plugins/zarg/check-completions.zsh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,8 +7,9 @@ the repo is cloned — nothing to build.
 Every script takes `--help`, `--version` and `--completions zsh|fish|bash`, all
 derived from the same [zarg](../zsh-plugins/zarg/README.md) declaration it
 parses with. Shared output helpers live in [`lib/common.zsh`](lib/common.zsh);
-[`lib/check-completions`](lib/check-completions) asserts every emitted
-completion actually parses in its target shell, and runs on pre-push and in CI.
+zarg's [`check-completions.zsh`](../zsh-plugins/zarg/check-completions.zsh)
+asserts every emitted completion actually parses in its target shell, and runs
+on pre-push and in CI.
 
 ---
 

--- a/zsh-plugins/zarg/README.md
+++ b/zsh-plugins/zarg/README.md
@@ -115,3 +115,17 @@ sets (`values=`) work everywhere.
 The emitters live in `completions.zsh` and are sourced only when asked for.
 Scripts load zarg on every invocation and generate completions roughly once per
 converge, so keeping them out of the hot path is worth the extra file.
+
+## Tests
+
+```sh
+zsh zsh-plugins/zarg/test.zsh                # zarg itself, against a fixture
+zsh zsh-plugins/zarg/check-completions.zsh   # every real consumer
+```
+
+`test.zsh` covers parsing, precedence, errors, help and the shape of all three
+emitters. `check-completions.zsh` sweeps `scripts/` and every plugin `bin/`,
+and pipes each script's emitted completion into the shell it targets — so a
+spec that parses but renders a broken compdef fails here rather than the next
+time you press tab. Both run on pre-push and in CI, where fish is installed so
+its output is parsed rather than merely generated.

--- a/zsh-plugins/zarg/check-completions.zsh
+++ b/zsh-plugins/zarg/check-completions.zsh
@@ -1,9 +1,9 @@
 #!/usr/bin/env zsh
-# Prove every zarg script still parses, renders help, and emits completions the
-# target shells actually accept. zarg exists so a completion cannot drift from
-# its parser; this is what makes that claim testable.
+# zarg's integration test: prove every script using it still parses, renders
+# help, and emits completions the target shells actually accept. test.zsh
+# covers zarg against a fixture; this covers it against real consumers.
 #
-# Run bare to check everything, or pass specific scripts.
+# Run bare to sweep scripts/ and every plugin bin/, or pass specific files.
 set -o pipefail
 
 local -a targets


### PR DESCRIPTION
`scripts/lib/check-completions` → `zsh-plugins/zarg/check-completions.zsh`.

It greps consumers for `zarg_go` and pipes zarg's emitted completions into the shells they target. That's zarg's integration test — it sat in the scripts' helper directory only because that's where I happened to write it.

Now it lives next to the unit suite it complements:

```sh
zsh zsh-plugins/zarg/test.zsh                # zarg itself, against a fixture
zsh zsh-plugins/zarg/check-completions.zsh   # every real consumer
```

`scripts/lib/` is left holding just `common.zsh`, which is what it claimed to be — `_dt_*` output helpers, nothing to do with parsing.

## Details worth checking

- **The `.zsh` suffix is load-bearing.** CI's syntax step globs `zsh-plugins/*/*.zsh`; without the suffix the file would have silently dropped out of that check.
- **Path depth is unchanged.** `scripts/lib/x` and `zsh-plugins/zarg/x` are both three levels down, so the `${0:A:h:h:h}` root resolution still lands on the repo root — verified by running it from a different cwd.
- It doesn't try to check itself: the sweep greps for a leading `zarg_go`, which this file doesn't have.

## Verify

```sh
zsh zsh-plugins/zarg/test.zsh                # 32 passed
zsh zsh-plugins/zarg/check-completions.zsh   # 16 scripts incl. wtclean
```

I also reproduced CI's syntax loop locally in bash to confirm the moved file is still picked up, and re-ran the sweep from `/tmp` to confirm path resolution.

References updated in `lefthook.yml`, `.github/workflows/scripts.yml`, `scripts/README.md` and `CHANGELOG.md`; zarg's README gains a Tests section describing both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CzNvwMVqrpyy2N1vhHQui