### PR TITLE
refactor(wt): parse the remaining bins with zarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**The rest of the wt bins parse with zarg:**
+
+- `wtclean` moved to zarg in #82; the other four were still hand-rolled, which is the drift zarg exists to prevent. All five now derive `--help`, the parser and the completions from one declaration, and unknown flags are refused with a did-you-mean rather than ignored
+- Branch arguments declare `complete=_wt_branches`, reusing the function already backing the `wt` and `wtrm` compdefs instead of a second list of worktrees
+- Registered in `generate:completions:plugin`, the by-path variant — plugin internals aren't on `PATH`, so the `command -v` gate the ordinary tools use would skip them silently
+
+
 **`crates/` is gone — 15 binaries become 15 zsh scripts:**
 
 - 3097 lines of Rust and **326 transitive crates** for tools that mostly shuffled argv. Ten of the fifteen shelled out to `ffmpeg`, `metaflac`, `aria2c`, `unzip`, `beet` or `exiftool` anyway, so the Rust was a progress bar wrapped around someone else's program. `git2` vendored libgit2, which is the only reason `setup-linux` installed `build-essential`; `reqwest` + rustls came along for two HTTP GETs that `curl` already does. The replacements total roughly 250 lines and need nothing that wasn't already installed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -611,6 +611,22 @@ tasks:
         vars:
           TOOL: wtclean
           BIN: "{{.DOTFILES}}/zsh-plugins/wt-core/bin/wtclean"
+      - task: generate:completions:plugin
+        vars:
+          TOOL: wt-list
+          BIN: "{{.DOTFILES}}/zsh-plugins/wt-core/bin/wt-list"
+      - task: generate:completions:plugin
+        vars:
+          TOOL: wt-preview
+          BIN: "{{.DOTFILES}}/zsh-plugins/wt-core/bin/wt-preview"
+      - task: generate:completions:plugin
+        vars:
+          TOOL: wt-picker
+          BIN: "{{.DOTFILES}}/zsh-plugins/wt-zellij/bin/wt-picker"
+      - task: generate:completions:plugin
+        vars:
+          TOOL: wt-shell
+          BIN: "{{.DOTFILES}}/zsh-plugins/wt-zellij/bin/wt-shell"
       # Custom completion commands
       - task: generate:completions:gen
         vars: { TOOL: aube, CMD: "aube completion zsh" }

--- a/zsh-plugins/wt-core/README.md
+++ b/zsh-plugins/wt-core/README.md
@@ -76,13 +76,19 @@ backend is only ever the two functions above.
 
 ## Bin
 
-Everything here is zsh — these are zsh plugins, zsh is guaranteed present, and
-macOS still ships bash 3.2.
+All zsh, and all parse with [`zarg`](../zarg) — one declaration yields the
+parser, `--help` and the completions, so a flag can't exist in one and not the
+other. `task generate:completions` picks them up through
+`generate:completions:plugin`, which takes a path: these live in plugins, not
+on `PATH`.
 
-`wt-list` prints `branch<TAB>path` per worktree, or the path of a named branch.
-Parsing `worktree list --porcelain` lived in four places and drifted; this is
-the one copy. `wt-preview` renders the fzf preview: PR details if there's a PR,
-otherwise log plus tree.
+`wt-list` prints `branch<TAB>path` per worktree, or resolves one branch to its
+path. Parsing `worktree list --porcelain` lived in four places and drifted;
+this is the one copy. `wt-preview` renders the fzf preview: PR details if
+there's a PR, otherwise log plus tree.
+
+Branch arguments complete via `_wt_branches`, the same function backing the
+`wt` and `wtrm` compdefs.
 
 `wtclean` is a script rather than a function, and `wtclean()` in the plugin is
 a one-line shim onto it. A function is only worth defining when it has to
@@ -90,7 +96,6 @@ mutate the shell — `wt` and `wtrm` cd, so they qualify; a GC pass doesn't. The
 difference matters: a shell started before an update will happily run a stale
 function against changed helpers and half-succeed, which is exactly how a run
 once reported `removed 0, kept 0` while still deleting seven branches.
-
 ## Exports
 
 `WT_CORE_BIN` — this plugin's `bin/`, for sibling plugins and previews.

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -1,11 +1,20 @@
 #!/usr/bin/env zsh
-# Emits "branch<TAB>path", one worktree per line. With an argument, prints only
-# the path of that branch. Parsing `worktree list --porcelain` lived in four
-# places and drifted; this is the one copy.
-# Branch is empty for detached worktrees — callers that display it filter those.
+# Emits "branch<TAB>path", one worktree per line. Parsing
+# `worktree list --porcelain` lived in four places and drifted; this is the
+# one copy. Branch is empty for detached worktrees — callers that display it
+# filter those.
+source "${0:A:h:h:h}/zarg/zarg.plugin.zsh" || {
+  print -u2 "wt-list: cannot load zarg"
+  exit 1
+}
+
+zarg_init wt-list 'List worktrees as "branch<TAB>path", or resolve one branch to its path'
+zarg_arg branch 'print only this branch, as a bare path' complete=_wt_branches
+zarg_go "$@"
+
 set -o pipefail
 
-git worktree list --porcelain 2>/dev/null | awk -v want="${1:-}" '
+git worktree list --porcelain 2>/dev/null | awk -v want="${branch:-}" '
   function emit() {
     if (want == "") printf "%s\t%s\n", b, p
     else if (b == want) print p

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -1,10 +1,19 @@
 #!/usr/bin/env zsh
-# Preview for wt fzf picker
-# Shows PR details if one exists, otherwise git log + file tree
-# Args: $1 = "branch\tpath" or just "branch" (fzf-tab sends $word)
+# Preview for the wt fzf pickers: PR details when a PR exists, otherwise git
+# log plus a file tree. fzf-tab sends the whole "branch<TAB>path" line, so the
+# branch is taken up to the first tab.
+source "${0:A:h:h:h}/zarg/zarg.plugin.zsh" || {
+  print -u2 "wt-preview: cannot load zarg"
+  exit 1
+}
+
+zarg_init wt-preview 'Render the fzf preview for a worktree'
+zarg_arg branch 'worktree branch to preview' required complete=_wt_branches
+zarg_go "$@"
+
 set -euo pipefail
 
-branch="${1%%$'\t'*}"
+branch="${branch%%$'\t'*}"
 path=$("${0:A:h}/wt-list" "$branch")
 [[ -n $path ]] || exit 0
 

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -1,8 +1,15 @@
 #!/usr/bin/env zsh
-# Worktree picker for the Zellij keybinding.
+# Worktree picker for the Zellij alt+w binding.
 # Pager commands (view/checks/diff) display in the floating pane via less.
-set -o pipefail
+source "${0:A:h:h:h}/zarg/zarg.plugin.zsh" || {
+  print -u2 "wt-picker: cannot load zarg"
+  exit 1
+}
 
+zarg_init wt-picker 'fzf over worktrees: enter opens or creates, ^x removes, ^r pulls, ^v/^y/^d/^l are PR view/checks/diff/create'
+zarg_go "$@"
+
+set -o pipefail
 export CLICOLOR_FORCE=1
 export GH_FORCE_TTY=1
 

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -1,10 +1,20 @@
 #!/usr/bin/env zsh
-# Wrapper shell for worktree tabs — auto-cleans or prompts on exit
-# Args: $1 = worktree path, $2 = branch name
+# Wrapper shell for worktree tabs — auto-cleans or prompts on exit.
+# Invoked by wtt, not by hand.
+source "${0:A:h:h:h}/zarg/zarg.plugin.zsh" || {
+  print -u2 "wt-shell: cannot load zarg"
+  exit 1
+}
+
+zarg_init wt-shell 'Run a shell in a worktree tab, then remove the worktree on exit if it is clean'
+zarg_arg worktree 'worktree path' required
+zarg_arg branch 'branch name' required complete=_wt_branches
+zarg_go "$@"
+
 set -euo pipefail
 
-wt="$1"
-name="$2"
+wt="$worktree"
+name="$branch"
 
 dim=$'\033[2m'
 bold=$'\033[1m'


### PR DESCRIPTION
## What this does

#82 moved `wtclean` to zarg and left the other four bins hand-rolled. This finishes the job: `wt-list`, `wt-preview`, `wt-picker` and `wt-shell` now declare their interface once and get the parser, `--help` and completions from it.

Registered in `generate:completions:plugin` — the by-path variant #82 added, since these live in plugins rather than on `PATH` and the usual `command -v` gate would skip them without saying so.

## Why this and not #80

**#80 should be closed.** It did the same job by hand — a `case` statement per script emitting a literal `#compdef` heredoc — and invented its own by-path Taskfile entry, which would now duplicate `generate:completions:plugin`. zarg's whole premise is that a hand-written parser/compdef pair drifts the moment you add a flag, and #80 is four instances of exactly that pair. Superseded on both counts.

## Load-bearing decisions

- **Branch arguments use `complete=_wt_branches`** rather than a fresh worktree listing. That function already backs the `wt` and `wtrm` compdefs, so there's one place that knows how to enumerate worktrees for completion.
- **zarg is sourced before `set -euo pipefail`**, not after. It exits the script itself on a parse error, so it doesn't need `-e`, and running it under `-u` risks tripping over its own optional-variable handling for no benefit.
- **`wt-preview` keeps the tab-stripping.** fzf-tab passes the whole `branch<TAB>path` line as one word, so `${branch%%$'\t'*}` still applies after zarg binds it.
- **~1.5ms** to source zarg, measured — irrelevant for `wt-preview`, which is already making a `gh pr view` call per render.

## How to confirm

```sh
zsh-plugins/wt-core/bin/wt-list --help
zsh-plugins/wt-core/bin/wt-list --nope          # rc=2, did-you-mean
task generate:completions
```

Verified: all five emit completions that parse under `zsh -n`; `compinit` registers every one from a scratch `fpath` (`wt-list -> _wt-list` and so on); `wt-list` still lists and still resolves a single branch; `wt-preview` still previews; required positionals are enforced on `wt-shell`.

## Not covered by testing

`wt-picker` and `wt-shell` past their argument handling — both need a TTY, and `wt-picker` with no arguments blocks on fzf by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK2s5sJBVLc5Edhm3cZ3H