### PR TITLE
refactor(zarg): a dispatcher too, matching dt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**zarg is a dispatcher too, matching `dt`:**
+
+- `zarg init`, `zarg flag`, `zarg opt`, `zarg arg`, `zarg go` — one autoloadable name, verb after it, same shape as `dt`
+- The two were barrelled differently for a circumstantial reason, not a principled one: `zarg` was always the first call, so it could declare its siblings as a side effect, while `dt` had no such entry point and needed a dispatcher. Making both dispatchers removes the asymmetry
+- `zarg parse` is the verb a shell *function* wants — it returns rather than exiting, where `zarg go` would take the user's shell down with it
+
+
 **`dt` — one name for the scripts' toolkit:**
 
 - The output helpers were `_dt_head`, `_dt_ok`, `_dt_fan` and nine more, every one named in every prelude. They are now subcommands of a single `dt`, so a script autoloads two things and gets both libraries: `autoload +X -Uz zarg dt || exit 1`
@@ -22,7 +29,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 - All 39 relative `source "${0:A:h:h}/..."` lines are gone. A script now says what it wants and nothing about where it lives: `autoload -Uz zarg _dt_head _dt_info`. One name covers zarg — `zarg` is always the first call, so it declares the rest of the API
 - Two dead ends on the way. A `~/.zshenv` works but has to hardcode `~/.dotfiles` — `.zshenv` cannot self-locate, `$0` is `zsh` — so a worktree's scripts would silently load main's libraries. And no plugin manager can help: sheldon, antigen and oh-my-zsh all run at `.zshrc` time, which a `#!/usr/bin/env zsh` script never reaches
 - `scripts/lib/common.zsh` split into `scripts/lib/functions/`, same treatment. Colours moved into an idempotent `_dt_colors` every output helper calls, since there is no longer a load-time block to set them
-- zarg had to survive being autoloaded without its loader: `zarg` now declares the state the rest of the library reads, and `zarg_version` finds the repo through `$functions_source` rather than a `ZARG_HOME` set at source time. Every function declares its own private helpers, so autoloading the public names is enough
+- zarg had to survive being autoloaded without its loader: `zarg` now declares the state the rest of the library reads, and `zarg version` finds the repo through `$functions_source` rather than a `ZARG_HOME` set at source time. Every function declares its own private helpers, so autoloading the public names is enough
 - `wtclean` was the last holdout — it needed `WT_CORE_BIN` from the plugin. `autoload +X` loads a function immediately rather than on first call, which populates `$functions_source`, so it derives its sibling `bin/` from where `_wt_root` came from
 
 **What this costs:** a script with no zsh ancestor — cron, a systemd unit, CI — inherits no `FPATH` and must set one. `check-completions.zsh` does that from its own location, which also means a worktree tests its own libraries rather than `~/.dotfiles`'.
@@ -81,7 +88,7 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 **`wtclean` uses zarg too:**
 
 - It was already a script rather than a function — a GC pass has no reason to mutate the calling shell — so it drops its hand-rolled `[[ $1 == -n ]]` and gains `--help`, `--version`, a typo-correcting parser and the first completion it has ever had
-- The rest of `wt-*` deliberately doesn't. `wt` and `wtrm` `cd`, so they must stay functions, and zarg is wrong for functions on two counts: `zarg_go` calls `exit`, which in an interactive function kills the user's shell rather than the command, and `typeset -g` would leak parsed values and the `ZARG_*` spec arrays into the session. They keep `compdef` at load time
+- The rest of `wt-*` deliberately doesn't. `wt` and `wtrm` `cd`, so they must stay functions, and zarg is wrong for functions on two counts: `zarg go` calls `exit`, which in an interactive function kills the user's shell rather than the command, and `typeset -g` would leak parsed values and the `ZARG_*` spec arrays into the session. They keep `compdef` at load time
 - Needed a `generate:completions:plugin` task: `wtclean` is reached through a shell function, so `command -v wtclean` finds nothing from inside a task and the usual generator would have skipped it silently
 
 **Behaviour that deliberately changed:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -253,10 +253,10 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg my-tool 'What it does'
-zarg_flag -n --dry-run 'show what would happen'
-zarg_arg  target 'thing to act on' required
-zarg_go "$@"
+zarg init my-tool 'What it does'
+zarg flag -n --dry-run 'show what would happen'
+zarg arg  target 'thing to act on' required
+zarg go "$@"
 
 dt head my-tool
 (( dry_run )) && { dt info "would act on $target"; exit 0 }

--- a/scripts/clean-dls
+++ b/scripts/clean-dls
@@ -4,10 +4,10 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg clean-dls 'Clean scene release garbage'
-zarg_flag -n --dry-run 'show what would be deleted'
-zarg_arg  paths 'directories to clean' variadic default=.
-zarg_go "$@"
+zarg init clean-dls 'Clean scene release garbage'
+zarg flag -n --dry-run 'show what would be deleted'
+zarg arg  paths 'directories to clean' variadic default=.
+zarg go "$@"
 
 # Word-boundary sample match on the stem (basename minus its last extension),
 # lowercased: exact "sample", sample- / sample_ / "sample " prefixes,

--- a/scripts/clean-exif
+++ b/scripts/clean-exif
@@ -4,10 +4,10 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg clean-exif 'Strip EXIF metadata from images'
-zarg_flag -n --dry-run 'show what would be cleaned'
-zarg_arg  paths 'directories to search' variadic default=.
-zarg_go "$@"
+zarg init clean-exif 'Strip EXIF metadata from images'
+zarg flag -n --dry-run 'show what would be cleaned'
+zarg arg  paths 'directories to search' variadic default=.
+zarg go "$@"
 
 dt need exiftool || exit 1
 dt head clean-exif

--- a/scripts/embed-art
+++ b/scripts/embed-art
@@ -4,9 +4,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg embed-art 'Embed artwork into FLAC files'
-zarg_arg paths 'directories to search' variadic default=.
-zarg_go "$@"
+zarg init embed-art 'Embed artwork into FLAC files'
+zarg arg paths 'directories to search' variadic default=.
+zarg go "$@"
 
 dt need metaflac clean-exif || exit 1
 dt head embed-art

--- a/scripts/extract-exif-from-flac
+++ b/scripts/extract-exif-from-flac
@@ -4,9 +4,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg extract-exif-from-flac 'Check FLAC embedded artwork for leftover EXIF data'
-zarg_arg flac_file 'FLAC file to check' required
-zarg_go "$@"
+zarg init extract-exif-from-flac 'Check FLAC embedded artwork for leftover EXIF data'
+zarg arg flac_file 'FLAC file to check' required
+zarg go "$@"
 
 dt need metaflac exiftool || exit 1
 [[ -f $flac_file ]] || { dt err "File not found: $flac_file"; exit 1 }

--- a/scripts/git-squash
+++ b/scripts/git-squash
@@ -4,10 +4,10 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg git-squash 'Squash commits for clean PR history'
-zarg_flag -n --dry-run 'show what would be squashed'
-zarg_arg  parent 'parent branch to squash onto' default=main
-zarg_go "$@"
+zarg init git-squash 'Squash commits for clean PR history'
+zarg flag -n --dry-run 'show what would be squashed'
+zarg arg  parent 'parent branch to squash onto' default=main
+zarg go "$@"
 
 git rev-parse --git-dir >/dev/null 2>&1 || { dt err "not a git repository"; exit 1 }
 dt head git-squash

--- a/scripts/git-sync
+++ b/scripts/git-sync
@@ -4,9 +4,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg git-sync 'Clean up merged branches'
-zarg_flag -y --yes 'delete without confirmation'
-zarg_go "$@"
+zarg init git-sync 'Clean up merged branches'
+zarg flag -y --yes 'delete without confirmation'
+zarg go "$@"
 
 DT_YES=$yes
 

--- a/scripts/imp
+++ b/scripts/imp
@@ -5,9 +5,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg imp 'Import music from URLs'
-zarg_arg urls 'URLs to download and import' required variadic
-zarg_go "$@"
+zarg init imp 'Import music from URLs'
+zarg arg urls 'URLs to download and import' required variadic
+zarg go "$@"
 
 dt need aria2c beet || exit 1
 dt head 'music importer'

--- a/scripts/kill-port
+++ b/scripts/kill-port
@@ -4,12 +4,12 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg kill-port 'Kill process listening on specified port'
-zarg_flag -n --dry-run 'show what would be killed without doing it'
-zarg_opt  -s --signal  'signal to send' default=TERM metavar=SIGNAL \
+zarg init kill-port 'Kill process listening on specified port'
+zarg flag -n --dry-run 'show what would be killed without doing it'
+zarg opt  -s --signal  'signal to send' default=TERM metavar=SIGNAL \
           values='TERM KILL INT HUP QUIT USR1 USR2'
-zarg_arg  port 'port number' required
-zarg_go "$@"
+zarg arg  port 'port number' required
+zarg go "$@"
 
 dt need lsof || exit 1
 dt head kill-port

--- a/scripts/parallel-dl-extract
+++ b/scripts/parallel-dl-extract
@@ -5,9 +5,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg parallel-dl-extract 'Parallel download and extract URLs using aria2c'
-zarg_arg urls 'URLs to download' required variadic
-zarg_go "$@"
+zarg init parallel-dl-extract 'Parallel download and extract URLs using aria2c'
+zarg arg urls 'URLs to download' required variadic
+zarg go "$@"
 
 dt need aria2c unzip || exit 1
 dt head 'parallel dl+extract'

--- a/scripts/prune
+++ b/scripts/prune
@@ -4,11 +4,11 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg prune 'Find and delete small directories'
-zarg_flag -y --yes      'delete without confirmation'
-zarg_opt  -s --min-size 'directories smaller than this are candidates, in KB' default=3072 env=MIN_SIZE metavar=KB
-zarg_arg  paths 'directories to search' variadic default=.
-zarg_go "$@"
+zarg init prune 'Find and delete small directories'
+zarg flag -y --yes      'delete without confirmation'
+zarg opt  -s --min-size 'directories smaller than this are candidates, in KB' default=3072 env=MIN_SIZE metavar=KB
+zarg arg  paths 'directories to search' variadic default=.
+zarg go "$@"
 
 DT_YES=$yes
 

--- a/scripts/prune-gen
+++ b/scripts/prune-gen
@@ -4,8 +4,8 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg prune-gen 'Generate a test directory structure for prune'
-zarg_go "$@"
+zarg init prune-gen 'Generate a test directory structure for prune'
+zarg go "$@"
 
 # Real bytes, not a sparse allocation: prune sizes directories with `du`, which
 # counts blocks on disk. A sparse 210M file reports as ~16K and the fixture

--- a/scripts/to-audio
+++ b/scripts/to-audio
@@ -4,13 +4,13 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg to-audio 'Convert audio files to FLAC or Opus'
-zarg_flag -k --keep    'keep original files'
-zarg_flag -n --dry-run 'show what would be converted'
-zarg_opt  -b --bitrate 'output bitrate in kbps (opus only)' default=160 env=BITRATE metavar=KBPS
-zarg_arg  format 'output format' required values='flac opus'
-zarg_arg  paths  'directories to search' variadic default=.
-zarg_go "$@"
+zarg init to-audio 'Convert audio files to FLAC or Opus'
+zarg flag -k --keep    'keep original files'
+zarg flag -n --dry-run 'show what would be converted'
+zarg opt  -b --bitrate 'output bitrate in kbps (opus only)' default=160 env=BITRATE metavar=KBPS
+zarg arg  format 'output format' required values='flac opus'
+zarg arg  paths  'directories to search' variadic default=.
+zarg go "$@"
 
 dt need ffmpeg || exit 1
 

--- a/scripts/unfuck-xcode
+++ b/scripts/unfuck-xcode
@@ -4,9 +4,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg unfuck-xcode 'Fix Xcode CLI Tools'
-zarg_flag -n --dry-run 'show what would be done'
-zarg_go "$@"
+zarg init unfuck-xcode 'Fix Xcode CLI Tools'
+zarg flag -n --dry-run 'show what would be done'
+zarg go "$@"
 
 [[ $OSTYPE == darwin* ]] || { dt err "macOS only"; exit 1 }
 dt head 'xcode unfucker'

--- a/scripts/url2base64
+++ b/scripts/url2base64
@@ -4,11 +4,11 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg url2base64 'Convert URLs to base64 data URLs'
-zarg_opt -t --mime-type 'MIME type for the data URL' default=image/svg+xml metavar=TYPE
-zarg_opt -T --timeout   'timeout in seconds' default=30 metavar=SECS
-zarg_arg url 'URL to fetch' required
-zarg_go "$@"
+zarg init url2base64 'Convert URLs to base64 data URLs'
+zarg opt -t --mime-type 'MIME type for the data URL' default=image/svg+xml metavar=TYPE
+zarg opt -T --timeout   'timeout in seconds' default=30 metavar=SECS
+zarg arg url 'URL to fetch' required
+zarg go "$@"
 
 dt need curl || exit 1
 

--- a/scripts/vimv
+++ b/scripts/vimv
@@ -4,9 +4,9 @@ set -o pipefail
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg vimv 'Batch rename files using your $EDITOR'
-zarg_arg  files 'files to rename' variadic
-zarg_go "$@"
+zarg init vimv 'Batch rename files using your $EDITOR'
+zarg arg  files 'files to rename' variadic
+zarg go "$@"
 
 dt head vimv
 

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -6,9 +6,9 @@
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg wt-list 'List worktrees as "branch<TAB>path", or resolve one branch to its path'
-zarg_arg branch 'print only this branch, as a bare path' complete=_wt_branches
-zarg_go "$@"
+zarg init wt-list 'List worktrees as "branch<TAB>path", or resolve one branch to its path'
+zarg arg branch 'print only this branch, as a bare path' complete=_wt_branches
+zarg go "$@"
 
 set -o pipefail
 

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -5,9 +5,9 @@
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg wt-preview 'Render the fzf preview for a worktree'
-zarg_arg branch 'worktree branch to preview' required complete=_wt_branches
-zarg_go "$@"
+zarg init wt-preview 'Render the fzf preview for a worktree'
+zarg arg branch 'worktree branch to preview' required complete=_wt_branches
+zarg go "$@"
 
 set -euo pipefail
 

--- a/zsh-plugins/wt-core/bin/wtclean
+++ b/zsh-plugins/wt-core/bin/wtclean
@@ -15,9 +15,9 @@ typeset -gA _wt_prs
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg wtclean 'Remove worktrees whose PR is merged or closed, keeping anything dirty'
-zarg_flag -n --dry-run 'show what would be removed without touching anything'
-zarg_go "$@"
+zarg init wtclean 'Remove worktrees whose PR is merged or closed, keeping anything dirty'
+zarg flag -n --dry-run 'show what would be removed without touching anything'
+zarg go "$@"
 
 set -o pipefail
 

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -4,8 +4,8 @@
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg wt-picker 'fzf over worktrees: enter opens or creates, ^x removes, ^r pulls, ^v/^y/^d/^l are PR view/checks/diff/create'
-zarg_go "$@"
+zarg init wt-picker 'fzf over worktrees: enter opens or creates, ^x removes, ^r pulls, ^v/^y/^d/^l are PR view/checks/diff/create'
+zarg go "$@"
 
 set -o pipefail
 export CLICOLOR_FORCE=1

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -4,10 +4,10 @@
 
 autoload +X -Uz zarg dt || exit 1
 
-zarg wt-shell 'Run a shell in a worktree tab, then remove the worktree on exit if it is clean'
-zarg_arg worktree 'worktree path' required
-zarg_arg branch 'branch name' required complete=_wt_branches
-zarg_go "$@"
+zarg init wt-shell 'Run a shell in a worktree tab, then remove the worktree on exit if it is clean'
+zarg arg worktree 'worktree path' required
+zarg arg branch 'branch name' required complete=_wt_branches
+zarg go "$@"
 
 set -euo pipefail
 

--- a/zsh-plugins/zarg/README.md
+++ b/zsh-plugins/zarg/README.md
@@ -18,14 +18,14 @@ set -o pipefail
 
 autoload +X -Uz zarg || exit 1
 
-zarg backup 'Back up a directory'
-zarg_flag -n --dry-run  'show what would be copied, copy nothing'
-zarg_flag -v --verbose  'list every file'
-zarg_opt  -c --compress 'compression to use'   default=zstd values='none gzip zstd'
-zarg_opt  -k --keep     'how many to retain'   default=7 env=BACKUP_KEEP metavar=N
-zarg_arg  source  'directory to back up'       required
-zarg_arg  targets 'where to put it'            variadic default=/backup
-zarg_go "$@"
+zarg init backup 'Back up a directory'
+zarg flag -n --dry-run  'show what would be copied, copy nothing'
+zarg flag -v --verbose  'list every file'
+zarg opt  -c --compress 'compression to use'   default=zstd values='none gzip zstd'
+zarg opt  -k --keep     'how many to retain'   default=7 env=BACKUP_KEEP metavar=N
+zarg arg  source  'directory to back up'       required
+zarg arg  targets 'where to put it'            variadic default=/backup
+zarg go "$@"
 
 print -r -- "source=$source  targets=(${(j:, :)targets})"
 print -r -- "compress=$compress  keep=$keep"
@@ -89,10 +89,10 @@ long form with dashes turned to underscores:
 
 | Declared | Variable | Value |
 | --- | --- | --- |
-| `zarg_flag -n --dry-run` | `$dry_run` | `0` or `1` |
-| `zarg_opt -k --keep` | `$keep` | the string |
-| `zarg_arg source` | `$source` | the string |
-| `zarg_arg targets … variadic` | `$targets` | an array |
+| `zarg flag -n --dry-run` | `$dry_run` | `0` or `1` |
+| `zarg opt -k --keep` | `$keep` | the string |
+| `zarg arg source` | `$source` | the string |
+| `zarg arg targets … variadic` | `$targets` | an array |
 
 Plain variables rather than an associative array (`$zarg[keep]`) is a
 deliberate trade: `(( dry_run ))` and `$keep` read better in the body than the
@@ -101,7 +101,7 @@ zarg writes into your namespace, so a spec is refused if it would bind a name
 zsh reserves:
 
 ```console
-$ zarg_opt -p --path 'where'
+$ zarg opt -p --path 'where'
 zarg: cannot bind 'path' — zsh reserves it for shell state
 ```
 
@@ -115,7 +115,7 @@ Declared default, then environment, then the command line — each overriding th
 last:
 
 ```zsh
-zarg_opt -k --keep 'how many to retain' default=7 env=BACKUP_KEEP
+zarg opt -k --keep 'how many to retain' default=7 env=BACKUP_KEEP
 ```
 
 ```console
@@ -128,11 +128,11 @@ $ BACKUP_KEEP=90 backup -k 30 ~/D   # keep=30   (command line wins)
 
 | Builder | Purpose |
 | --- | --- |
-| `zarg <name> <description>` | start a spec |
-| `zarg_flag <short> <long> <help>` | boolean, `0` or `1` |
-| `zarg_opt <short> <long> <help> [extras]` | takes a value |
-| `zarg_arg <name> <help> [extras]` | positional |
-| `zarg_go "$@"` | handle built-ins, parse, exit on error |
+| `zarg init <name> <description>` | start a spec |
+| `zarg flag <short> <long> <help>` | boolean, `0` or `1` |
+| `zarg opt <short> <long> <help> [extras]` | takes a value |
+| `zarg arg <name> <help> [extras]` | positional |
+| `zarg go "$@"` | handle built-ins, parse, exit on error |
 
 Extras are `key=value` pairs, or bare words for the boolean ones:
 
@@ -146,7 +146,7 @@ Extras are `key=value` pairs, or bare words for the boolean ones:
 | `required` | arg | error if absent |
 | `variadic` | arg | collect the rest into an array; declare it last |
 
-`zarg_go` exits the script itself for `--help`, `--version` and
+`zarg go` exits the script itself for `--help`, `--version` and
 `--completions`, and on a parse error. Once it returns, the parse succeeded —
 scripts do not check its result.
 

--- a/zsh-plugins/zarg/check-completions.zsh
+++ b/zsh-plugins/zarg/check-completions.zsh
@@ -30,7 +30,7 @@ _fail() { print -ru2 -- "  FAIL  $1"; (( failures++ )) }
 
 for f in $targets; do
   [[ -f $f && -x $f ]] || continue
-  grep -q '^zarg_go' "$f" 2>/dev/null || continue
+  grep -q '^zarg go' "$f" 2>/dev/null || continue
   name=${f:t}
 
   zsh -n "$f"                 || _fail "$name: syntax"

--- a/zsh-plugins/zarg/functions/zarg
+++ b/zsh-plugins/zarg/functions/zarg
@@ -1,11 +1,16 @@
-# zarg <name> <description> — opens a spec.
+# zarg — declarative argument parsing. One autoloadable name; the verb picks
+# the rest:
 #
-# The only name a consumer needs: it pulls in the rest of the API, and declares
-# the state that API reads, so autoloading this one function is enough even
-# when nobody sourced the loader.
+#   zarg init <name> <description>   open a spec
+#   zarg flag <short> <long> <help>  boolean, 0 or 1
+#   zarg opt  <short> <long> <help> [default= env= values= complete= metavar=]
+#   zarg arg  <name> <help> [required variadic default= values= complete=]
+#   zarg go   "$@"                   built-ins, parse, exit on error
+#   zarg parse "$@"                  same but returns instead of exiting — what
+#                                    a shell *function* must use, since exit
+#                                    would kill the user's shell
 #
-# Records are \x1f-delimited because help text may contain anything else.
-autoload -Uz zarg_arg zarg_completions zarg_flag zarg_go zarg_help zarg_opt zarg_parse zarg_version
-typeset -g  ZARG_SEP=$'\x1f'
-typeset -g  ZARG_NAME=$1 ZARG_DESC=$2
-typeset -ga ZARG_FLAGS=() ZARG_OPTS=() ZARG_ARGS=()
+# Each verb is its own file, loaded on first use. See README.md.
+local cmd=$1; shift
+autoload -Uz zarg_$cmd
+zarg_$cmd "$@"

--- a/zsh-plugins/zarg/functions/zarg_init
+++ b/zsh-plugins/zarg/functions/zarg_init
@@ -1,0 +1,9 @@
+# zarg init <name> <description> — opens a spec.
+#
+# Declares the state the rest of the library reads, so a consumer that only
+# autoloads the dispatcher works without anyone sourcing the loader.
+#
+# Records are \x1f-delimited because help text may contain anything else.
+typeset -g  ZARG_SEP=$'\x1f'
+typeset -g  ZARG_NAME=$1 ZARG_DESC=$2
+typeset -ga ZARG_FLAGS=() ZARG_OPTS=() ZARG_ARGS=()

--- a/zsh-plugins/zarg/test.zsh
+++ b/zsh-plugins/zarg/test.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 # zarg's test suite. Run: zsh zsh-plugins/zarg/test.zsh
 #
-# Each case runs a fixture script in a subshell, because zarg_go exits the
+# Each case runs a fixture script in a subshell, because zarg go exits the
 # process for --help, errors and the like — which is exactly the behaviour
 # under test.
 
@@ -12,14 +12,14 @@ trap 'rm -rf ${fixture:h}' EXIT
 cat > "$fixture" <<EOF
 #!/usr/bin/env zsh
 source "$here/zarg.plugin.zsh"
-zarg spec 'a test spec'
-zarg_flag -n --dry-run 'do nothing'
-zarg_flag -k --keep    'keep things'
-zarg_opt  -s --signal  'a signal' default=TERM values='TERM KILL INT'
-zarg_opt  -b --bitrate 'a bitrate' default=160 env=BITRATE
-zarg_arg  port  'a port' required
-zarg_arg  paths 'some paths' variadic default=.
-zarg_go "\$@"
+zarg init spec 'a test spec'
+zarg flag -n --dry-run 'do nothing'
+zarg flag -k --keep    'keep things'
+zarg opt  -s --signal  'a signal' default=TERM values='TERM KILL INT'
+zarg opt  -b --bitrate 'a bitrate' default=160 env=BITRATE
+zarg arg  port  'a port' required
+zarg arg  paths 'some paths' variadic default=.
+zarg go "\$@"
 print -r -- "dry_run=\$dry_run keep=\$keep signal=\$signal bitrate=\$bitrate port=\$port paths=\${(j:,:)paths}"
 EOF
 chmod +x "$fixture"
@@ -104,7 +104,7 @@ fi
 reserved() {
   local name=$1 decl=$2
   local got; got=$(zsh -c "source '$here/zarg.plugin.zsh'
-    zarg t 'x'
+    zarg init t 'x'
     $decl
     print -r -- \"PATH_OK=\$(( \${#path} > 0 ))\"" 2>&1)
   if [[ $got == *"cannot bind '$name'"* && $got == *PATH_OK=1* ]]; then (( pass++ ))
@@ -112,9 +112,9 @@ reserved() {
   got: $got"
   fi
 }
-reserved path  'zarg_opt -p --path "boom"'
-reserved fpath 'zarg_arg fpath "boom"'
-reserved PATH  'zarg_flag -P --PATH "boom"'
+reserved path  'zarg opt -p --path "boom"'
+reserved fpath 'zarg arg fpath "boom"'
+reserved PATH  'zarg flag -P --PATH "boom"'
 
 print -r -- "zarg: $pass passed, $fail failed"
 (( fail == 0 ))


### PR DESCRIPTION
`zarg init` / `flag` / `opt` / `arg` / `go` — one autoloadable name, verb after it, same shape as `dt`.

```zsh
autoload +X -Uz zarg dt || exit 1

zarg init kill-port 'Kill process listening on specified port'
zarg flag -n --dry-run 'show what would be killed without doing it'
zarg opt  -s --signal  'signal to send' default=TERM values='TERM KILL INT'
zarg arg  port 'port number' required
zarg go "$@"

dt need lsof || exit 1
dt head kill-port
```

## Why they differed

Not a design decision — an accident of shape. `zarg` was **always the first call**, so it could declare its siblings as a side effect and leave `zarg_flag` and friends as ordinary functions. `dt` had no mandatory entry point, so nothing guaranteed a declaration would fire, and only a dispatcher works there.

Both are dispatchers now, so there's one rule instead of two.

`zarg parse` is worth knowing about: it returns instead of exiting, which is what a shell **function** needs — `zarg go` would take the user's shell down with it. Verified that a function using `zarg parse` reports a missing argument and leaves the shell alive.

## Verified

- 35 zarg tests and all 20 consumers' completions, under `env -u FPATH`
- `--help`, value-set rejection (`-s 9`), did-you-mean (`--dry-ru`), and positional value sets (`to-audio mp3`) all still derive from the spec
- Both wt bins run
- External-consumer shape: a plain shell function using `zarg init` + `zarg parse` works and survives an error

## Two self-inflicted bugs caught on the way

- Branched off a stale `origin/main` and lost `dt` — reset onto the right base before doing anything.
- The doc rewrite produced `zarg init go "$@"`, because the regex for the bare `zarg <tool> '<desc>'` call also matched `zarg go "$@"` once the verb form existed. Scripts were unaffected (the bare rule ran while they still said `zarg_go`), but the docs needed a second pass. Swept for `zarg init <verb>` afterwards — none left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CzNvwMVqrpyy2N1vhHQui