### PR TITLE
refactor: zarg and dt are the names you autoload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,43 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
-**One shape for both libraries: `zarg_init` and `dt_init`.**
+**`zarg` and `dt` are the names you autoload:**
 
-- Each is the single name a consumer autoloads; calling it sets up that library's state and declares the rest of its family. `autoload +X -Uz zarg_init dt_init || exit 1` is the whole prelude
+```zsh
+autoload +X -Uz zarg dt && dt || exit 1
+
+zarg kill-port 'Kill process listening on specified port'
+zarg_flag -n --dry-run 'show what would be killed without doing it'
+zarg_go "$@"
+
+dt_need lsof || exit 1
+dt_head kill-port
+```
+
+- The init function *is* the library name, and `&& dt` folds its call into the line that was already there. All three branches checked: both present, zarg missing, dt missing — the last two exit 1
+- Individual functions still autoload on their own: `autoload +X -Uz dt_need || exit 1` then `dt_need myapp` works, because each is a self-contained file that declares its own helpers
+- That exposed a gap worth closing: skipping `dt` left the colour parameters unset, so a stand-alone helper printed uncoloured. The six output helpers now fall back to calling `dt` themselves — one parameter test, and only on the path where nothing has initialised yet
+
+
+**One shape for both libraries: `zarg` and `dt`.**
+
+- Each is the single name a consumer autoloads; calling it sets up that library's state and declares the rest of its family. `autoload +X -Uz zarg dt || exit 1` is the whole prelude
 - Snake case throughout — `zarg_flag`, `dt_need` — so a name says which library it belongs to. The dispatcher form (`zarg flag`, `dt need`) read fine but severed that link
-- `dt_init` earns the call it costs: colours are computed once there instead of every output helper re-checking them, which is what the old `_dt_colors` guard did on every printed line
+- `dt` earns the call it costs: colours are computed once there instead of every output helper re-checking them, which is what the old `_dt_colors` guard did on every printed line
 - A load-time barrel is not possible, which is what forced the shape. `autoload +X` loads a function's definition without running it, under both `-Uz` and `-Uk`, so declarations inside a barrel never fire — the entry point has to actually be called
-- `00-prelude.zsh` now autoloads and calls `dt_init` for the interactive shell, so conf.d files can use `dt_warn`/`dt_need` instead of hand-rolled printf. Declarations do not cross into child processes, so scripts still autoload it themselves
+- `00-prelude.zsh` now autoloads and calls `dt` for the interactive shell, so conf.d files can use `dt_warn`/`dt_need` instead of hand-rolled printf. Declarations do not cross into child processes, so scripts still autoload it themselves
 
 
 **zarg is a dispatcher too, matching `dt`:**
 
-- `zarg_init`, `zarg_flag`, `zarg_opt`, `zarg_arg`, `zarg_go` — one autoloadable name, verb after it, same shape as `dt`
+- `zarg`, `zarg_flag`, `zarg_opt`, `zarg_arg`, `zarg_go` — one autoloadable name, verb after it, same shape as `dt`
 - The two were barrelled differently for a circumstantial reason, not a principled one: `zarg` was always the first call, so it could declare its siblings as a side effect, while `dt` had no such entry point and needed a dispatcher. Making both dispatchers removes the asymmetry
 - `zarg_parse` is the verb a shell *function* wants — it returns rather than exiting, where `zarg_go` would take the user's shell down with it
 
 
 **`dt` — one name for the scripts' toolkit:**
 
-- The output helpers were `_dt_head`, `_dt_ok`, `_dt_fan` and nine more, every one named in every prelude. They are now subcommands of a single `dt`, so a script autoloads two things and gets both libraries: `autoload +X -Uz zarg_init dt_init || exit 1`
+- The output helpers were `_dt_head`, `_dt_ok`, `_dt_fan` and nine more, every one named in every prelude. They are now subcommands of a single `dt`, so a script autoloads two things and gets both libraries: `autoload +X -Uz zarg dt || exit 1`
 - It reads better at the call site too. `dt_head kill-port`, `dt_ok "killed PID $pid"`, `dt_need lsof` — the verb carries the meaning, where `_dt_` carried none
 - A barrel that merely *declares* the rest cannot work: `autoload +X` loads a function's definition but does not run it, so the declarations inside would never fire. A dispatcher is the shape that does, and it keeps the laziness — each helper is still its own file, loaded on first use
 - `extract-exif-from-flac` had a script-local `_dt_pic_desc` squatting on the library's prefix; renamed to `_pic_desc`

--- a/config.d/zsh/conf.d/00-prelude.zsh
+++ b/config.d/zsh/conf.d/00-prelude.zsh
@@ -45,7 +45,7 @@ SAVEHIST=50000
 # scripts autoload it themselves; this is purely for the interactive shell.
 if [[ -d ~/.dotfiles/scripts/lib/functions ]]; then
   fpath=(~/.dotfiles/scripts/lib/functions $fpath)
-  autoload -Uz dt_init && dt_init
+  autoload -Uz dt && dt
 fi
 
 # Add custom completions to fpath before compinit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -251,9 +251,9 @@ Copy the shape of [`kill-port`](kill-port) — it is the reference:
 # One line on WHY this exists.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init my-tool 'What it does'
+zarg my-tool 'What it does'
 zarg_flag -n --dry-run 'show what would happen'
 zarg_arg  target 'thing to act on' required
 zarg_go "$@"

--- a/scripts/clean-dls
+++ b/scripts/clean-dls
@@ -2,14 +2,12 @@
 # Strip scene-release garbage (nfo/sfv/sample/junk) out of a download tree.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init clean-dls 'Clean scene release garbage'
+zarg clean-dls 'Clean scene release garbage'
 zarg_flag -n --dry-run 'show what would be deleted'
 zarg_arg  paths 'directories to clean' variadic default=.
 zarg_go "$@"
-
-dt_init
 
 # Word-boundary sample match on the stem (basename minus its last extension),
 # lowercased: exact "sample", sample- / sample_ / "sample " prefixes,

--- a/scripts/clean-exif
+++ b/scripts/clean-exif
@@ -2,14 +2,12 @@
 # Strip EXIF (and XMP/IPTC/ICC) metadata from images before sharing them.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init clean-exif 'Strip EXIF metadata from images'
+zarg clean-exif 'Strip EXIF metadata from images'
 zarg_flag -n --dry-run 'show what would be cleaned'
 zarg_arg  paths 'directories to search' variadic default=.
 zarg_go "$@"
-
-dt_init
 
 dt_need exiftool || exit 1
 dt_head clean-exif

--- a/scripts/embed-art
+++ b/scripts/embed-art
@@ -2,13 +2,11 @@
 # Embed cover/disc/back/artist art from each FLAC's own directory.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init embed-art 'Embed artwork into FLAC files'
+zarg embed-art 'Embed artwork into FLAC files'
 zarg_arg paths 'directories to search' variadic default=.
 zarg_go "$@"
-
-dt_init
 
 dt_need metaflac clean-exif || exit 1
 dt_head embed-art

--- a/scripts/extract-exif-from-flac
+++ b/scripts/extract-exif-from-flac
@@ -2,13 +2,11 @@
 # Check whether art embedded in a FLAC still carries EXIF that should've been stripped.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init extract-exif-from-flac 'Check FLAC embedded artwork for leftover EXIF data'
+zarg extract-exif-from-flac 'Check FLAC embedded artwork for leftover EXIF data'
 zarg_arg flac_file 'FLAC file to check' required
 zarg_go "$@"
-
-dt_init
 
 dt_need metaflac exiftool || exit 1
 [[ -f $flac_file ]] || { dt_err "File not found: $flac_file"; exit 1 }

--- a/scripts/git-squash
+++ b/scripts/git-squash
@@ -2,14 +2,12 @@
 # Squash a branch's commits into one before opening a PR.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init git-squash 'Squash commits for clean PR history'
+zarg git-squash 'Squash commits for clean PR history'
 zarg_flag -n --dry-run 'show what would be squashed'
 zarg_arg  parent 'parent branch to squash onto' default=main
 zarg_go "$@"
-
-dt_init
 
 git rev-parse --git-dir >/dev/null 2>&1 || { dt_err "not a git repository"; exit 1 }
 dt_head git-squash

--- a/scripts/git-sync
+++ b/scripts/git-sync
@@ -2,13 +2,11 @@
 # Delete local branches whose upstream got deleted after a merge.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init git-sync 'Clean up merged branches'
+zarg git-sync 'Clean up merged branches'
 zarg_flag -y --yes 'delete without confirmation'
 zarg_go "$@"
-
-dt_init
 
 DT_YES=$yes
 

--- a/scripts/imp
+++ b/scripts/imp
@@ -3,13 +3,11 @@
 # beets one at a time — beets' importer is interactive and expects one album.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init imp 'Import music from URLs'
+zarg imp 'Import music from URLs'
 zarg_arg urls 'URLs to download and import' required variadic
 zarg_go "$@"
-
-dt_init
 
 dt_need aria2c beet || exit 1
 dt_head 'music importer'

--- a/scripts/kill-port
+++ b/scripts/kill-port
@@ -2,16 +2,14 @@
 # Kill whatever holds a port — the "address already in use" fix.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init kill-port 'Kill process listening on specified port'
+zarg kill-port 'Kill process listening on specified port'
 zarg_flag -n --dry-run 'show what would be killed without doing it'
 zarg_opt  -s --signal  'signal to send' default=TERM metavar=SIGNAL \
           values='TERM KILL INT HUP QUIT USR1 USR2'
 zarg_arg  port 'port number' required
 zarg_go "$@"
-
-dt_init
 
 dt_need lsof || exit 1
 dt_head kill-port

--- a/scripts/lib/functions/dt
+++ b/scripts/lib/functions/dt
@@ -1,4 +1,4 @@
-# dt_init — sets up the output layer and declares the rest of the family, so a
+# dt — sets up the output layer and declares the rest of the family, so a
 # consumer autoloads this one name. Call it before the first dt_* line.
 #
 # Colours live here rather than in each helper: they are read-only after this

--- a/scripts/lib/functions/dt_err
+++ b/scripts/lib/functions/dt_err
@@ -1,1 +1,5 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -ru2 -- "  ${_dt_red}󰅖${_dt_off} $*"

--- a/scripts/lib/functions/dt_head
+++ b/scripts/lib/functions/dt_head
@@ -1,3 +1,7 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -r -- ""
 print -r -- "  ${_dt_mag}${_dt_bold}⟢${_dt_off} ${_dt_bold}$1${_dt_off}"
 print -r -- ""

--- a/scripts/lib/functions/dt_info
+++ b/scripts/lib/functions/dt_info
@@ -1,1 +1,5 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -r -- "  ${_dt_cyan}→${_dt_off} $*"

--- a/scripts/lib/functions/dt_ok
+++ b/scripts/lib/functions/dt_ok
@@ -1,1 +1,5 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -r -- "  ${_dt_green}󰄬${_dt_off} $*"

--- a/scripts/lib/functions/dt_step
+++ b/scripts/lib/functions/dt_step
@@ -1,1 +1,5 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -r -- "  ${_dt_grey}·${_dt_off} $*"

--- a/scripts/lib/functions/dt_warn
+++ b/scripts/lib/functions/dt_warn
@@ -1,1 +1,5 @@
+# Stand-alone use (`autoload -Uz dt_ok; dt_ok x`) skips dt, so colours
+# would be unset. One parameter test is cheaper than getting it wrong.
+autoload -Uz dt
+(( ${+_dt_off} )) || dt
 print -r -- "  ${_dt_yellow}󰀪${_dt_off} $*"

--- a/scripts/parallel-dl-extract
+++ b/scripts/parallel-dl-extract
@@ -3,13 +3,11 @@
 # whatever lands. Fetching serially wastes the per-download connection cap.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init parallel-dl-extract 'Parallel download and extract URLs using aria2c'
+zarg parallel-dl-extract 'Parallel download and extract URLs using aria2c'
 zarg_arg urls 'URLs to download' required variadic
 zarg_go "$@"
-
-dt_init
 
 dt_need aria2c unzip || exit 1
 dt_head 'parallel dl+extract'

--- a/scripts/prune
+++ b/scripts/prune
@@ -2,15 +2,13 @@
 # Find and delete small directories cluttering a tree.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init prune 'Find and delete small directories'
+zarg prune 'Find and delete small directories'
 zarg_flag -y --yes      'delete without confirmation'
 zarg_opt  -s --min-size 'directories smaller than this are candidates, in KB' default=3072 env=MIN_SIZE metavar=KB
 zarg_arg  paths 'directories to search' variadic default=.
 zarg_go "$@"
-
-dt_init
 
 DT_YES=$yes
 

--- a/scripts/prune-gen
+++ b/scripts/prune-gen
@@ -2,12 +2,10 @@
 # Build a throwaway directory tree to exercise prune against.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init prune-gen 'Generate a test directory structure for prune'
+zarg prune-gen 'Generate a test directory structure for prune'
 zarg_go "$@"
-
-dt_init
 
 # Real bytes, not a sparse allocation: prune sizes directories with `du`, which
 # counts blocks on disk. A sparse 210M file reports as ~16K and the fixture

--- a/scripts/to-audio
+++ b/scripts/to-audio
@@ -2,17 +2,15 @@
 # Bulk audio conversion — replaces the old separate flac/opus subcommands.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init to-audio 'Convert audio files to FLAC or Opus'
+zarg to-audio 'Convert audio files to FLAC or Opus'
 zarg_flag -k --keep    'keep original files'
 zarg_flag -n --dry-run 'show what would be converted'
 zarg_opt  -b --bitrate 'output bitrate in kbps (opus only)' default=160 env=BITRATE metavar=KBPS
 zarg_arg  format 'output format' required values='flac opus'
 zarg_arg  paths  'directories to search' variadic default=.
 zarg_go "$@"
-
-dt_init
 
 dt_need ffmpeg || exit 1
 

--- a/scripts/unfuck-xcode
+++ b/scripts/unfuck-xcode
@@ -2,13 +2,11 @@
 # Nuke and reinstall Xcode CLI Tools when they get stuck in a broken state.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init unfuck-xcode 'Fix Xcode CLI Tools'
+zarg unfuck-xcode 'Fix Xcode CLI Tools'
 zarg_flag -n --dry-run 'show what would be done'
 zarg_go "$@"
-
-dt_init
 
 [[ $OSTYPE == darwin* ]] || { dt_err "macOS only"; exit 1 }
 dt_head 'xcode unfucker'

--- a/scripts/url2base64
+++ b/scripts/url2base64
@@ -2,15 +2,13 @@
 # Fetch a URL and emit it as a base64 data URL — for inlining assets in CSS/HTML.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init url2base64 'Convert URLs to base64 data URLs'
+zarg url2base64 'Convert URLs to base64 data URLs'
 zarg_opt -t --mime-type 'MIME type for the data URL' default=image/svg+xml metavar=TYPE
 zarg_opt -T --timeout   'timeout in seconds' default=30 metavar=SECS
 zarg_arg url 'URL to fetch' required
 zarg_go "$@"
-
-dt_init
 
 dt_need curl || exit 1
 

--- a/scripts/vimv
+++ b/scripts/vimv
@@ -2,13 +2,11 @@
 # Batch rename by editing a file list in $EDITOR, mv/git-mv-ing the diff back.
 set -o pipefail
 
-autoload +X -Uz zarg_init dt_init || exit 1
+autoload +X -Uz zarg dt && dt || exit 1
 
-zarg_init vimv 'Batch rename files using your $EDITOR'
+zarg vimv 'Batch rename files using your $EDITOR'
 zarg_arg  files 'files to rename' variadic
 zarg_go "$@"
-
-dt_init
 
 dt_head vimv
 

--- a/zsh-plugins/wt-core/bin/wt-list
+++ b/zsh-plugins/wt-core/bin/wt-list
@@ -4,9 +4,9 @@
 # one copy. Branch is empty for detached worktrees — callers that display it
 # filter those.
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init wt-list 'List worktrees as "branch<TAB>path", or resolve one branch to its path'
+zarg wt-list 'List worktrees as "branch<TAB>path", or resolve one branch to its path'
 zarg_arg branch 'print only this branch, as a bare path' complete=_wt_branches
 zarg_go "$@"
 

--- a/zsh-plugins/wt-core/bin/wt-preview
+++ b/zsh-plugins/wt-core/bin/wt-preview
@@ -3,9 +3,9 @@
 # log plus a file tree. fzf-tab sends the whole "branch<TAB>path" line, so the
 # branch is taken up to the first tab.
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init wt-preview 'Render the fzf preview for a worktree'
+zarg wt-preview 'Render the fzf preview for a worktree'
 zarg_arg branch 'worktree branch to preview' required complete=_wt_branches
 zarg_go "$@"
 

--- a/zsh-plugins/wt-core/bin/wtclean
+++ b/zsh-plugins/wt-core/bin/wtclean
@@ -13,9 +13,9 @@ autoload +X -Uz _wt_root _wt_base _wt_named _wt_pr_state
 # ${_wt_prs[feat/x]} an arithmetic subscript, where "feat/x" is a division.
 typeset -gA _wt_prs
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init wtclean 'Remove worktrees whose PR is merged or closed, keeping anything dirty'
+zarg wtclean 'Remove worktrees whose PR is merged or closed, keeping anything dirty'
 zarg_flag -n --dry-run 'show what would be removed without touching anything'
 zarg_go "$@"
 

--- a/zsh-plugins/wt-zellij/bin/wt-picker
+++ b/zsh-plugins/wt-zellij/bin/wt-picker
@@ -2,9 +2,9 @@
 # Worktree picker for the Zellij alt+w binding.
 # Pager commands (view/checks/diff) display in the floating pane via less.
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init wt-picker 'fzf over worktrees: enter opens or creates, ^x removes, ^r pulls, ^v/^y/^d/^l are PR view/checks/diff/create'
+zarg wt-picker 'fzf over worktrees: enter opens or creates, ^x removes, ^r pulls, ^v/^y/^d/^l are PR view/checks/diff/create'
 zarg_go "$@"
 
 set -o pipefail

--- a/zsh-plugins/wt-zellij/bin/wt-shell
+++ b/zsh-plugins/wt-zellij/bin/wt-shell
@@ -2,9 +2,9 @@
 # Wrapper shell for worktree tabs — auto-cleans or prompts on exit.
 # Invoked by wtt, not by hand.
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init wt-shell 'Run a shell in a worktree tab, then remove the worktree on exit if it is clean'
+zarg wt-shell 'Run a shell in a worktree tab, then remove the worktree on exit if it is clean'
 zarg_arg worktree 'worktree path' required
 zarg_arg branch 'branch name' required complete=_wt_branches
 zarg_go "$@"

--- a/zsh-plugins/zarg/README.md
+++ b/zsh-plugins/zarg/README.md
@@ -16,9 +16,9 @@ from one declaration makes that failure mode unrepresentable.
 # Back up a directory somewhere, with the usual knobs.
 set -o pipefail
 
-autoload +X -Uz zarg_init || exit 1
+autoload +X -Uz zarg || exit 1
 
-zarg_init backup 'Back up a directory'
+zarg backup 'Back up a directory'
 zarg_flag -n --dry-run  'show what would be copied, copy nothing'
 zarg_flag -v --verbose  'list every file'
 zarg_opt  -c --compress 'compression to use'   default=zstd values='none gzip zstd'
@@ -128,7 +128,7 @@ $ BACKUP_KEEP=90 backup -k 30 ~/D   # keep=30   (command line wins)
 
 | Builder | Purpose |
 | --- | --- |
-| `zarg_init <name> <description>` | start a spec |
+| `zarg <name> <description>` | start a spec |
 | `zarg_flag <short> <long> <help>` | boolean, `0` or `1` |
 | `zarg_opt <short> <long> <help> [extras]` | takes a value |
 | `zarg_arg <name> <help> [extras]` | positional |

--- a/zsh-plugins/zarg/functions/zarg
+++ b/zsh-plugins/zarg/functions/zarg
@@ -1,4 +1,4 @@
-# zarg_init <name> <description> — opens a spec and declares the rest of the
+# zarg <name> <description> — opens a spec and declares the rest of the
 # family, so a consumer autoloads this one name.
 #
 # It also declares the state the API reads, which is what lets a consumer skip

--- a/zsh-plugins/zarg/test.zsh
+++ b/zsh-plugins/zarg/test.zsh
@@ -12,7 +12,7 @@ trap 'rm -rf ${fixture:h}' EXIT
 cat > "$fixture" <<EOF
 #!/usr/bin/env zsh
 source "$here/zarg.plugin.zsh"
-zarg_init spec 'a test spec'
+zarg spec 'a test spec'
 zarg_flag -n --dry-run 'do nothing'
 zarg_flag -k --keep    'keep things'
 zarg_opt  -s --signal  'a signal' default=TERM values='TERM KILL INT'
@@ -104,7 +104,7 @@ fi
 reserved() {
   local name=$1 decl=$2
   local got; got=$(zsh -c "source '$here/zarg.plugin.zsh'
-    zarg_init t 'x'
+    zarg t 'x'
     $decl
     print -r -- \"PATH_OK=\$(( \${#path} > 0 ))\"" 2>&1)
   if [[ $got == *"cannot bind '$name'"* && $got == *PATH_OK=1* ]]; then (( pass++ ))


### PR DESCRIPTION
The init function *is* the library name, and `&&` folds its call into the line that was already there.

```zsh
autoload +X -Uz zarg dt && dt || exit 1

zarg kill-port 'Kill process listening on specified port'
zarg_flag -n --dry-run 'show what would be killed without doing it'
zarg_opt  -s --signal  'signal to send' default=TERM values='TERM KILL INT'
zarg_arg  port 'port number' required
zarg_go "$@"

dt_need lsof || exit 1
dt_head kill-port
```

## The `&&` chain is safe

Worth checking rather than assuming, since a wrong exit status here would kill every script:

| | result |
| --- | --- |
| both present | body reached, colours initialised |
| `zarg` missing | exit 1 |
| `dt` missing | exit 1 |
| `dt` return status | 0, piped or not — so `&& dt \|\| exit 1` can't misfire |

## You can still autoload one thing

```zsh
autoload +X -Uz dt_need || exit 1
dt_need myapp
```

Works — each function is a self-contained file that declares its own helpers.

That did expose a gap. Skipping `dt` left the colour parameters unset, so a stand-alone helper printed uncoloured. The six output helpers now fall back to calling `dt` themselves — one parameter test, and only on the path where nothing has initialised yet, so scripts (which always run `dt` in the prelude) never pay it. Verified with a real pty: coloured on a tty, plain when piped.

## Verified

- 35 zarg tests, all 20 consumers' completions, under `env -u FPATH`
- `dt_fan`/`dt_files` — `to-audio` still converts `a b.wav` with the space intact
- `dt_confirm` — answering `n` to `prune` cancels
- fail-fast — `prune --help` with `FPATH` unset exits 1
- wt bins run; they autoload only `zarg`, having no output helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CzNvwMVqrpyy2N1vhHQui