### PR TITLE
Run Claude in auto mode instead of bypassPermissions

### DIFF
--- a/.claude-personal/settings.json
+++ b/.claude-personal/settings.json
@@ -1,13 +1,6 @@
 {
-  "enabledPlugins": {
-    "rust-analyzer-lsp@claude-plugins-official": true
-  },
-  "skipDangerousModePermissionPrompt": true,
-  "theme": "auto",
-  "agentPushNotifEnabled": true,
-  "remoteControlAtStartup": true,
   "permissions": {
-    "defaultMode": "bypassPermissions"
+    "defaultMode": "auto"
   },
   "hooks": {
     "SessionStart": [
@@ -22,5 +15,11 @@
         ]
       }
     ]
-  }
+  },
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
+  },
+  "theme": "auto",
+  "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true
 }

--- a/.claude-work/settings.json
+++ b/.claude-work/settings.json
@@ -1,16 +1,8 @@
 {
   "permissions": {
-    "defaultMode": "bypassPermissions"
+    "defaultMode": "auto"
   },
-  "model": "opus[1m]",
-  "effortLevel": "high",
-  "skipDangerousModePermissionPrompt": true,
-  "theme": "dark",
-  "editorMode": "normal",
-  "preferredNotifChannel": "ghostty",
-  "teammateMode": "in-process",
-  "remoteControlAtStartup": true,
-  "tui": "fullscreen",
+  "model": "fable",
   "hooks": {
     "SessionStart": [
       {
@@ -37,5 +29,12 @@
         "repo": "oliver-kriska/claude-elixir-phoenix"
       }
     }
-  }
+  },
+  "effortLevel": "high",
+  "tui": "fullscreen",
+  "theme": "dark",
+  "editorMode": "normal",
+  "preferredNotifChannel": "ghostty",
+  "teammateMode": "in-process",
+  "remoteControlAtStartup": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A history of this dotfiles repo from its inception in May 2018 through February 
 
 ### August
 
+**Claude runs in auto mode, not bypass.**
+
+- Both profiles were `defaultMode: bypassPermissions` — every tool call waved through, on the host, with no sandbox. Auto mode still runs read-only and reversible work unprompted; it just stops short of the things worth a second's thought
+- `skipDangerousModePermissionPrompt` went with it. Its only job is silencing the warning on `--dangerously-skip-permissions`, so leaving it set means the one launch where you fat-finger that flag is also the one that never tells you
+- The lima jail keeps `bypassPermissionsModeAccepted`. Throwaway VM, no host filesystem — that is the entire reason it exists
+
 **Gastown removed.**
 
 - The `gastown-file-changed.sh` hook fired on every Write/Edit and no-op'd the moment it found no `gt` on `$PATH` — a fork per edit to discover it had nothing to do


### PR DESCRIPTION
Both Claude profiles ran `defaultMode: bypassPermissions` — every tool call waved through, on the host filesystem, no sandbox. This switches both to `auto`, which still runs read-only and reversible work unprompted and asks about the rest.

`skipDangerousModePermissionPrompt: true` goes with it. That flag exists solely to silence the warning shown when launching with `--dangerously-skip-permissions`; with it set, the one launch where that flag gets fat-fingered is also the one that never warns you.

`config.d/lima/isolated.yaml` deliberately keeps `bypassPermissionsModeAccepted` — throwaway VM with no host filesystem, which is the whole reason the jail exists.

## Verify

```
jq .permissions.defaultMode .claude-personal/settings.json .claude-work/settings.json   # "auto" x2
jq 'has("skipDangerousModePermissionPrompt")' .claude-{personal,work}/settings.json     # false x2
```

Both files parse as valid JSON. The `.claude-work` diff also carries an unrelated key reorder plus `model` and `enabledPlugins` changes that Claude Code itself wrote to the file before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GELyv7tGroxEDfULT5njn